### PR TITLE
Sync subinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ A subroutine stash name, e.g. `main`
 
 Setter for subroutine stash name.
 
+## subinfo
+
+A subroutine information, e.g. `['main', 'hello']`
+
+## set\_subinfo(\[$stashname, $subname\])
+
+Setter for subroutine information.
+
 ## file
 
 A filename where subroutine is defined, e.g. `path/to/main.pl`.

--- a/t/01_meta.t
+++ b/t/01_meta.t
@@ -1,6 +1,7 @@
 use Test2::V0;
 
 use Sub::Meta;
+use Sub::Identify;
 
 subtest 'non sub' => sub {
     my $meta = Sub::Meta->new;
@@ -29,7 +30,7 @@ subtest 'has sub' => sub {
         is $meta->fullname, 'main::hello', 'fullname';
         is $meta->stashname, 'main', 'stashname';
         is $meta->file, 't/01_meta.t', 'file';
-        is $meta->line, 23, 'line';
+        is $meta->line, 24, 'line';
         ok !$meta->is_constant, 'is_constant';
         is $meta->prototype, '$$', 'prototype';
         is $meta->attribute, ['method'], 'attribute';
@@ -44,12 +45,25 @@ subtest 'has sub' => sub {
         my $meta = Sub::Meta->new(sub => \&hello);
         is $meta->set_sub(\&hello2), $meta, 'set_sub';
         is $meta->sub, \&hello2, 'subname';
+
         is $meta->set_subname('world'), $meta, 'set_subname';
         is $meta->subname, 'world', 'subname';
-        is $meta->set_fullname('test::world'), $meta, 'set_fullname';
-        is $meta->fullname, 'test::world', 'fullname';
+        is $meta->stashname, 'main', 'stashname';
+        is $meta->fullname, 'main::world', 'fullname';
+        is $meta->subinfo, ['main', 'world'], 'subinfo';
+
+        is $meta->set_fullname('foo::bar::baz'), $meta, 'set_fullname';
+        is $meta->subname, 'baz', 'subname';
+        is $meta->fullname, 'foo::bar::baz', 'fullname';
+        is $meta->stashname, 'foo::bar', 'stashname';
+        is $meta->subinfo, ['foo::bar', 'baz'], 'subinfo';
+
         is $meta->set_stashname('test'), $meta, 'set_stashname';
+        is $meta->subname, 'baz', 'subname';
+        is $meta->fullname, 'test::baz', 'fullname';
         is $meta->stashname, 'test', 'stashname';
+        is $meta->subinfo, ['test', 'baz'], 'subinfo';
+
         is $meta->set_file('test/file.t'), $meta, 'set_file';
         is $meta->file, 'test/file.t', 'file';
         is $meta->set_line(999), $meta, 'set_line';
@@ -73,7 +87,7 @@ subtest 'has sub' => sub {
         my $meta = Sub::Meta->new(sub => \&hello3);
         is $meta->apply_subname('HELLO'), $meta, 'apply_subname';
         is $meta->subname, 'HELLO', 'subname';
-        is $meta->_build_subname, 'HELLO', 'build_subname';
+        is [ Sub::Identify::get_code_info(\&hello3) ], ['main','HELLO'], 'build_subinfo';
 
         is $meta->apply_prototype('$'), $meta, 'apply_prototype';
         is $meta->prototype, '$', 'prototype';


### PR DESCRIPTION
# why synchronize subinfo

for convenience.

**BEFORE:**
```perl
$meta->subname; # foo

$meta->set_subname("bar");
$meta->subname; # bar
$meta->fullname;  # main::foo <- NOT convenience
```

**AFTER:**
```perl
$meta->subname; # foo

$meta->set_subname("bar");
$meta->subname; # bar
$meta->fullname;  # main::bar
```

# TODO

- [x] sync subinfo
- [x] add `subinfo` method

