### PR TITLE
Fix Sub::Meta#new

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sub::Meta - handle subroutine meta information
 use Sub::Meta;
 
 sub hello($) :mehtod { }
-my $meta = Sub::Meta->new(\&hello);
+my $meta = Sub::Meta->new(sub => \&hello);
 $meta->subname; # => hello
 
 $meta->sub;        # \&hello
@@ -55,6 +55,18 @@ $meta->returns->scalar; # 'Str'
 ## new
 
 Constructor of `Sub::Meta`.
+
+```perl
+Sub::Meta->new(
+    fullname    => 'Greeting::hello',
+    is_constant => 0,
+    prototype   => '$',
+    attribute   => ['method'],
+    is_method   => 1,
+    parameters  => Sub::Meta::Parameters->new(args => [{ type => 'Str' }]),
+    returns     => Sub::Meta::Returns->new('Str'),
+);
+```
 
 ## sub
 

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -24,7 +24,14 @@ sub _croak { require Carp; Carp::croak(@_) }
 sub new {
     my $class = shift;
     my %args = @_ == 1 ? %{$_[0]} : @_;
-    bless \%args => $class;
+
+    my $self = bless \%args => $class;
+
+    $self->set_subname(delete $args{subname})     if exists $args{subname};
+    $self->set_stashname(delete $args{stashname}) if exists $args{stashname};
+    $self->set_fullname(delete $args{fullname})   if exists $args{fullname};
+
+    return $self;
 }
 
 sub sub()         { $_[0]{sub} }

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -136,7 +136,7 @@ Sub::Meta - handle subroutine meta information
     use Sub::Meta;
 
     sub hello($) :mehtod { }
-    my $meta = Sub::Meta->new(\&hello);
+    my $meta = Sub::Meta->new(sub => \&hello);
     $meta->subname; # => hello
 
     $meta->sub;        # \&hello
@@ -180,6 +180,16 @@ C<Sub::Meta> provides methods to handle subroutine meta information. In addition
 =head2 new
 
 Constructor of C<Sub::Meta>.
+
+    Sub::Meta->new(
+        fullname    => 'Greeting::hello',
+        is_constant => 0,
+        prototype   => '$',
+        attribute   => ['method'],
+        is_method   => 1,
+        parameters  => Sub::Meta::Parameters->new(args => [{ type => 'Str' }]),
+        returns     => Sub::Meta::Returns->new('Str'),
+    );
 
 =head2 sub
 

--- a/t/01_meta.t
+++ b/t/01_meta.t
@@ -118,6 +118,10 @@ subtest 'has sub' => sub {
 subtest 'new' => sub {
     sub test_new { }
     is(Sub::Meta->new({ sub => \&test_new})->sub, \&test_new, 'args hashref');
+
+    is(Sub::Meta->new(subname => 'foo')->subname, 'foo', 'subname args');
+    is(Sub::Meta->new(stashname => 'foo')->stashname, 'foo', 'stashname args');
+    is(Sub::Meta->new(fullname => 'foo::bar')->fullname, 'foo::bar', 'fullname args');
 };
 
 subtest 'constant' => sub {


### PR DESCRIPTION
Allow `fullname`, `subname` and `stashname` as constructor arguments:

```perl
Sub::Meta->new(
   subname => 'foo',
   stashname => 'main',
   fullname => 'main::foo',
)
```