### PR TITLE
feat: improve Constructors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,27 +262,27 @@ $meta->set_args(['Str']);
 
 ## args
 
-The alias of `parameters-`args>.
+The alias of `parameters.args`.
 
 ## set\_args($args)
 
-The alias of `parameters-`set\_args>.
+The alias of `parameters.set_args`.
 
 ## nshift
 
-The alias of `parameters-`nshift>.
+The alias of `parameters.nshift`.
 
 ## set\_nshift($nshift)
 
-The alias of `parameters-`set\_nshift>.
+The alias of `parameters.set_nshift`.
 
 ## slurpy
 
-The alias of `parameters-`slurpy>.
+The alias of `parameters.slurpy`.
 
 ## set\_slurpy($slurpy)
 
-The alias of `parameters-`set\_slurpy>.
+The alias of `parameters.set_slurpy`.
 
 ## returns
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ Sub::Util::prototype($meta->sub); # $@
 And you can hold meta information of parameter type and return type. See also [Sub::Meta::Parameters](https://metacpan.org/pod/Sub%3A%3AMeta%3A%3AParameters) and [Sub::Meta::Returns](https://metacpan.org/pod/Sub%3A%3AMeta%3A%3AReturns).
 
 ```perl
-$meta->set_parameters( Sub::Meta::Parameters->new(args => [ { type => 'Str' }]) );
+$meta->set_parameters(args => ['Str']));
 $meta->parameters->args; # [ Sub::Meta::Param->new({ type => 'Str' }) ]
 
-$meta->set_returns( Sub::Meta::Returns->new('Str') );
+$meta->set_args(['Str']);
+$meta->args; # [ Sub::Meta::Param->new({ type => 'Str' }) ]
+
+$meta->set_returns('Str');
 $meta->returns->scalar; # 'Str'
+$meta->returns->list;   # 'Str'
 ```
 
 And you can compare meta informations:
@@ -65,14 +69,60 @@ $meta eq $other; # 1
 Constructor of `Sub::Meta`.
 
 ```perl
+use Sub::Meta;
+use Types::Standard -types;
+
+# sub Greeting::hello(Str) -> Str
 Sub::Meta->new(
     fullname    => 'Greeting::hello',
     is_constant => 0,
     prototype   => '$',
     attribute   => ['method'],
     is_method   => 1,
-    parameters  => Sub::Meta::Parameters->new(args => [{ type => 'Str' }]),
-    returns     => Sub::Meta::Returns->new('Str'),
+    parameters  => { args => [{ type => Str }]},
+    returns     => Str,
+);
+```
+
+Others are as follows:
+
+```perl
+# sub add(Int, Int) -> Int
+Sub::Meta->new(
+    name    => 'add',
+    args    => [Int, Int],
+    returns => Int,
+);
+
+# method hello(Str) -> Str 
+Sub::Meta->new(
+    name      => 'hello',
+    args      => [{ message => Str }],
+    is_method => 1,
+    returns   => Str,
+);
+
+# sub twice(@numbers) -> ArrayRef[Int]
+Sub::Meta->new(
+    name      => 'twice',
+    args      => [],
+    slurpy    => 1,
+    returns   => ArrayRef[Int],
+);
+
+# Named parameters:
+# sub foo(Str :a) -> Str
+Sub::Meta->new(
+    name      => 'foo',
+    args      => { a => Str },
+    returns   => Str,
+);
+
+# is equivalent to
+Sub::Meta->new(
+    name      => 'foo',
+    args      => [{ name => 'a', isa => Str, named => 1 }],
+    returns   => Str,
 );
 ```
 
@@ -196,17 +246,43 @@ Parameters object of [Sub::Meta::Parameters](https://metacpan.org/pod/Sub%3A%3AM
 
 ## set\_parameters($parameters)
 
-Sets the parameters object of [Sub::Meta::Parameters](https://metacpan.org/pod/Sub%3A%3AMeta%3A%3AParameters) or any object which has `positional`,`named`,`required` and `optional` methods.
+Sets the parameters object of [Sub::Meta::Parameters](https://metacpan.org/pod/Sub%3A%3AMeta%3A%3AParameters).
 
 ```perl
 my $meta = Sub::Meta->new;
-$meta->set_parameters({ type => 'Type'});
-$meta->parameters; # => Sub::Meta::Parameters->new({type => 'Type'});
+$meta->set_parameters(args => ['Str']);
+$meta->parameters; # => Sub::Meta::Parameters->new(args => ['Str']);
 
 # or
-$meta->set_parameters(Sub::Meta::Parameters->new(type => 'Foo'));
-$meta->set_parameters(MyParamters->new)
+$meta->set_parameters(Sub::Meta::Parameters->new(args => ['Str']));
+
+# alias
+$meta->set_args(['Str']);
 ```
+
+## args
+
+The alias of `parameters-`args>.
+
+## set\_args($args)
+
+The alias of `parameters-`set\_args>.
+
+## nshift
+
+The alias of `parameters-`nshift>.
+
+## set\_nshift($nshift)
+
+The alias of `parameters-`set\_nshift>.
+
+## slurpy
+
+The alias of `parameters-`slurpy>.
+
+## set\_slurpy($slurpy)
+
+The alias of `parameters-`set\_slurpy>.
 
 ## returns
 

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -107,8 +107,13 @@ sub set_is_method($)   { $_[0]{is_method}   = $_[1]; $_[0] }
 sub set_parameters {
     my $self = shift;
     my $v = $_[0];
-    if (Scalar::Util::blessed($v) && $v->isa('Sub::Meta::Parameters')) {
-        $self->{parameters} = $v
+    if (Scalar::Util::blessed($v)) {
+        if ($v->isa('Sub::Meta::Parameters')) {
+            $self->{parameters} = $v
+        }
+        else {
+            _croak('object must be Sub::Meta::Parameters');
+        }
     }
     else {
         $self->{parameters} = Sub::Meta::Parameters->new(@_);

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -469,27 +469,27 @@ Sets the parameters object of L<Sub::Meta::Parameters>.
 
 =head2 args
 
-The alias of C<parameters->args>.
+The alias of C<parameters.args>.
 
 =head2 set_args($args)
 
-The alias of C<parameters->set_args>.
+The alias of C<parameters.set_args>.
 
 =head2 nshift
 
-The alias of C<parameters->nshift>.
+The alias of C<parameters.nshift>.
 
 =head2 set_nshift($nshift)
 
-The alias of C<parameters->set_nshift>.
+The alias of C<parameters.set_nshift>.
 
 =head2 slurpy
 
-The alias of C<parameters->slurpy>.
+The alias of C<parameters.slurpy>.
 
 =head2 set_slurpy($slurpy)
 
-The alias of C<parameters->set_slurpy>.
+The alias of C<parameters.set_slurpy>.
 
 =head2 returns
 

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -36,8 +36,22 @@ sub new {
     $self->set_stashname(delete $args{stashname}) if exists $args{stashname};
     $self->set_fullname(delete $args{fullname})   if exists $args{fullname};
 
-    $self->set_parameters($args{parameters}) if exists $args{parameters};
-    $self->set_returns($args{returns})       if exists $args{returns};
+    if (exists $args{parameters}) {
+        $self->set_parameters($args{parameters})
+    }
+    elsif(exists $args{args}) {
+        $self->set_parameters(
+            args => delete $args{args},
+            ( exists $args{slurpy} ? (slurpy => delete $args{slurpy}) : () ),
+
+            ( exists $args{nshift}    ? (nshift => delete $args{nshift}) :
+              exists $args{is_method} ? (nshift => $args{is_method} ? 1 : 0) : () ),
+        );
+    }
+
+    if (exists $args{returns}) {
+        $self->set_returns($args{returns})
+    }
 
     return $self;
 }
@@ -56,9 +70,12 @@ sub line()        { $_[0]{line}        ||= $_[0]->_build_line }
 sub is_constant() { $_[0]{is_constant} ||= $_[0]->_build_is_constant }
 sub prototype()   { $_[0]{prototype}   ||= $_[0]->_build_prototype }
 sub attribute()   { $_[0]{attribute}   ||= $_[0]->_build_attribute }
-sub is_method()   { $_[0]{is_method} }
+sub is_method()   { !!$_[0]{is_method} }
 sub parameters()  { $_[0]{parameters} }
 sub returns()     { $_[0]{returns} }
+sub args()        { $_[0]->parameters->args }
+sub slurpy()      { $_[0]->parameters->slurpy }
+sub nshift()      { $_[0]->parameters->nshift }
 
 sub set_sub($)    {
     $_[0]{sub} = $_[1];
@@ -87,15 +104,53 @@ sub set_prototype($)   { $_[0]{prototype}   = $_[1]; $_[0] }
 sub set_attribute($)   { $_[0]{attribute}   = $_[1]; $_[0] }
 sub set_is_method($)   { $_[0]{is_method}   = $_[1]; $_[0] }
 
-sub set_parameters($) {
+sub set_parameters {
     my $self = shift;
-    $self->{parameters} = Scalar::Util::blessed($_[0]) ? $_[0] : Sub::Meta::Parameters->new(@_);
+    my $v = $_[0];
+    if (Scalar::Util::blessed($v) && $v->isa('Sub::Meta::Parameters')) {
+        $self->{parameters} = $v
+    }
+    else {
+        $self->{parameters} = Sub::Meta::Parameters->new(@_);
+    }
     return $self
 }
 
-sub set_returns($) {
+sub set_args {
     my $self = shift;
-    $self->{returns} =  Scalar::Util::blessed($_[0]) ? $_[0] : Sub::Meta::Returns->new(@_);
+    if ($self->parameters) {
+        $self->parameters->set_args(@_);
+    }
+    else {
+        $self->set_parameters(Sub::Meta::Parameters->new(args => @_));
+    }
+    return $self;
+}
+
+sub set_slurpy {
+    my $self = shift;
+    $self->parameters->set_slurpy(@_);
+    return $self;
+}
+
+sub set_nshift {
+    my $self = shift;
+    if ($self->is_method && $_[0] == 0) {
+        _croak 'nshift of method cannot be zero';
+    }
+    $self->parameters->set_nshift(@_);
+    return $self;
+}
+
+sub set_returns {
+    my $self = shift;
+    my $v = $_[0];
+    if (Scalar::Util::blessed($v) && $v->isa('Sub::Meta::Returns')) {
+        $self->{returns} = $v
+    }
+    else {
+        $self->{returns} = Sub::Meta::Returns->new(@_);
+    }
     return $self
 }
 
@@ -204,11 +259,15 @@ Sub::Meta - handle subroutine meta information
 
 And you can hold meta information of parameter type and return type. See also L<Sub::Meta::Parameters> and L<Sub::Meta::Returns>.
 
-    $meta->set_parameters( Sub::Meta::Parameters->new(args => [ { type => 'Str' }]) );
+    $meta->set_parameters(args => ['Str']));
     $meta->parameters->args; # [ Sub::Meta::Param->new({ type => 'Str' }) ]
+    
+    $meta->set_args(['Str']);
+    $meta->args; # [ Sub::Meta::Param->new({ type => 'Str' }) ]
 
-    $meta->set_returns( Sub::Meta::Returns->new('Str') );
+    $meta->set_returns('Str');
     $meta->returns->scalar; # 'Str'
+    $meta->returns->list;   # 'Str'
 
 And you can compare meta informations:
 
@@ -226,14 +285,58 @@ C<Sub::Meta> provides methods to handle subroutine meta information. In addition
 
 Constructor of C<Sub::Meta>.
 
+    use Sub::Meta;
+    use Types::Standard -types;
+
+    # sub Greeting::hello(Str) -> Str
     Sub::Meta->new(
         fullname    => 'Greeting::hello',
         is_constant => 0,
         prototype   => '$',
         attribute   => ['method'],
         is_method   => 1,
-        parameters  => Sub::Meta::Parameters->new(args => [{ type => 'Str' }]),
-        returns     => Sub::Meta::Returns->new('Str'),
+        parameters  => { args => [{ type => Str }]},
+        returns     => Str,
+    );
+
+Others are as follows:
+
+    # sub add(Int, Int) -> Int
+    Sub::Meta->new(
+        name    => 'add',
+        args    => [Int, Int],
+        returns => Int,
+    );
+
+    # method hello(Str) -> Str 
+    Sub::Meta->new(
+        name      => 'hello',
+        args      => [{ message => Str }],
+        is_method => 1,
+        returns   => Str,
+    );
+
+    # sub twice(@numbers) -> ArrayRef[Int]
+    Sub::Meta->new(
+        name      => 'twice',
+        args      => [],
+        slurpy    => 1,
+        returns   => ArrayRef[Int],
+    );
+
+    # Named parameters:
+    # sub foo(Str :a) -> Str
+    Sub::Meta->new(
+        name      => 'foo',
+        args      => { a => Str },
+        returns   => Str,
+    );
+
+    # is equivalent to
+    Sub::Meta->new(
+        name      => 'foo',
+        args      => [{ name => 'a', isa => Str, named => 1 }],
+        returns   => Str,
     );
 
 =head2 sub
@@ -352,15 +455,41 @@ Parameters object of L<Sub::Meta::Parameters>.
 
 =head2 set_parameters($parameters)
 
-Sets the parameters object of L<Sub::Meta::Parameters> or any object which has C<positional>,C<named>,C<required> and C<optional> methods.
+Sets the parameters object of L<Sub::Meta::Parameters>.
 
     my $meta = Sub::Meta->new;
-    $meta->set_parameters({ type => 'Type'});
-    $meta->parameters; # => Sub::Meta::Parameters->new({type => 'Type'});
+    $meta->set_parameters(args => ['Str']);
+    $meta->parameters; # => Sub::Meta::Parameters->new(args => ['Str']);
 
     # or
-    $meta->set_parameters(Sub::Meta::Parameters->new(type => 'Foo'));
-    $meta->set_parameters(MyParamters->new)
+    $meta->set_parameters(Sub::Meta::Parameters->new(args => ['Str']));
+
+    # alias
+    $meta->set_args(['Str']);
+
+=head2 args
+
+The alias of C<parameters->args>.
+
+=head2 set_args($args)
+
+The alias of C<parameters->set_args>.
+
+=head2 nshift
+
+The alias of C<parameters->nshift>.
+
+=head2 set_nshift($nshift)
+
+The alias of C<parameters->set_nshift>.
+
+=head2 slurpy
+
+The alias of C<parameters->slurpy>.
+
+=head2 set_slurpy($slurpy)
+
+The alias of C<parameters->set_slurpy>.
 
 =head2 returns
 

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -47,10 +47,10 @@ sub set_named($;)      { $_[0]{named}    = !!(defined $_[1] ? $_[1] : 1); $_[0] 
 sub set_positional($;) { $_[0]{named}    =  !(defined $_[1] ? $_[1] : 1); $_[0] }
 
 # alias
-sub isa_ :method :prototype(); # NOT isa
+sub isa_() :method; # NOT isa
 *isa_ = \&type;
 
-sub set_isa :prototype($);
+sub set_isa($);
 *set_isa = \&set_type;
 
 sub is_same_interface {

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -21,6 +21,7 @@ sub new {
 
     $args{optional} = !delete $args{required} if exists $args{required};
     $args{named}    = !delete $args{positional} if exists $args{positional};
+    $args{type}     = delete $args{isa} if exists $args{isa};
 
     %args = (%DEFAULT, %args);
 
@@ -44,6 +45,13 @@ sub set_optional($;)   { $_[0]{optional} = !!(defined $_[1] ? $_[1] : 1); $_[0] 
 sub set_required($;)   { $_[0]{optional} =  !(defined $_[1] ? $_[1] : 1); $_[0] }
 sub set_named($;)      { $_[0]{named}    = !!(defined $_[1] ? $_[1] : 1); $_[0] }
 sub set_positional($;) { $_[0]{named}    =  !(defined $_[1] ? $_[1] : 1); $_[0] }
+
+# alias
+sub isa_ :method :prototype(); # NOT isa
+*isa_ = \&type;
+
+sub set_isa :prototype($);
+*set_isa = \&set_type;
 
 sub is_same_interface {
     my ($self, $other) = @_;
@@ -128,6 +136,14 @@ Any type constraints, e.g. C<Str>.
 =head2 set_type($type)
 
 Setter for C<type>.
+
+=head2 isa_
+
+The alias of C<type>
+
+=head2 set_isa($type)
+
+The alias of C<set_type>
 
 =head2 default
 

--- a/t/01_meta.t
+++ b/t/01_meta.t
@@ -14,7 +14,7 @@ subtest 'non sub' => sub {
     is $meta->is_constant, undef, 'is_constant';
     is $meta->prototype, '', 'prototype';
     is $meta->attribute, undef, 'prototype';
-    is $meta->is_method, undef, 'is_method';
+    ok !$meta->is_method, 'is_method';
     is $meta->parameters, undef, 'parameters';
     is $meta->returns, undef, 'returns';
 };
@@ -34,7 +34,7 @@ subtest 'has sub' => sub {
         ok !$meta->is_constant, 'is_constant';
         is $meta->prototype, '$$', 'prototype';
         is $meta->attribute, ['method'], 'attribute';
-        is $meta->is_method, undef, 'is_method';
+        ok !$meta->is_method, 'is_method';
         is $meta->parameters, undef, 'parameters';
         is $meta->returns, undef, 'returns';
     };
@@ -80,9 +80,15 @@ subtest 'has sub' => sub {
         is $meta->set_attribute(['foo','bar']), $meta, 'set_attribute';
         is $meta->attribute, ['foo','bar'], 'attribute';
         is $meta->set_is_method(!!1), $meta, 'set_is_method';
-        is $meta->is_method, !!1, 'is_method';
+        ok $meta->is_method, 'is_method';
         is $meta->set_parameters(args => []), $meta, 'set_parameters';
         is $meta->parameters, Sub::Meta::Parameters->new(args => []), 'parameters';
+        is $meta->set_args(['Int']), $meta, 'set_args';
+        is $meta->args, Sub::Meta::Parameters->new(args => ['Int'])->args, 'args';
+        is $meta->set_nshift(1), $meta, 'set_nshift';
+        is $meta->nshift, 1, 'nshift';
+        is $meta->set_slurpy(1), $meta, 'set_slurpy';
+        is $meta->slurpy, 1, 'slurpy';
         is $meta->set_returns([]), $meta, 'set_returns';
         is $meta->returns, Sub::Meta::Returns->new([]), 'returns';
     };
@@ -138,15 +144,20 @@ subtest 'constant' => sub {
     }
 };
 
-subtest 'set_parameters/returns' => sub {
+subtest 'set_parameters/args/returns' => sub {
     my $meta = Sub::Meta->new;
 
     my $obj = bless {}, 'Some::Object';
-    $meta->set_parameters($obj);
-    is $meta->parameters, $obj, 'parameters can set any object';
+    $meta->set_parameters(args => [$obj]);
+    is $meta->parameters, Sub::Meta::Parameters->new(args => [{ type => $obj }]),
+        'if $obj is not Sub::Meta::Parameters, $obj will be treated as type';
+
+    $meta->set_args([$obj]);
+    is $meta->args, Sub::Meta::Parameters->new(args => [{ type => $obj }])->args, 'set_args';
 
     $meta->set_returns($obj);
-    is $meta->returns, $obj, 'return can set any object';
+    is $meta->returns, Sub::Meta::Returns->new($obj),
+        'if $obj is not Sub::Meta::Returns, $obj will be treated as type';
 };
 
 subtest 'set invalid fullname' => sub {

--- a/t/01_meta/new.t
+++ b/t/01_meta/new.t
@@ -1,0 +1,33 @@
+use Test2::V0;
+
+use Sub::Meta;
+use Sub::Meta::Parameters;
+
+use JSON::PP;
+my $json = JSON::PP->new->allow_nonref->convert_blessed->canonical;
+
+subtest 'args: parameters' => sub {
+    my $meta = Sub::Meta->new(
+        parameters => { args => ['Str'] },
+    );
+    is $meta->parameters, Sub::Meta::Parameters->new(args => ['Str']);
+};
+
+subtest 'args: args' => sub {
+
+    my $check = sub {
+        my ($a, $b) = @_;
+        my $meta = Sub::Meta->new($a);
+        my $parameters = Sub::Meta::Parameters->new($b);
+        is $meta->parameters, $parameters, $json->encode($a);
+    };
+
+    $check->({args => ['Str']}, {args => ['Str']});
+    $check->({args => ['Str'], slurpy => 1}, {args => ['Str'], slurpy => 1});
+    $check->({args => ['Str'], nshift => 1}, {args => ['Str'], nshift => 1});
+    $check->({args => ['Str'], is_method => 1}, {args => ['Str'], nshift => 1}, 'if is_method flag is set, then set nshift to 1' );
+    $check->({args => ['Str'], is_method => 0}, {args => ['Str'], nshift => 0});
+    $check->({args => ['Str'], nshift => 1, is_method => 0}, {args => ['Str'], nshift => 1}, 'nshift has priority');
+};
+
+done_testing;

--- a/t/02_parameters.t
+++ b/t/02_parameters.t
@@ -269,6 +269,11 @@ subtest '_normalize_args' => sub {
     is(Sub::Meta::Parameters->_normalize_args(
         { a => { isa => 'Foo' }, b => { isa => 'Bar' } }),
         [p(type => 'Foo', name => 'a', named => 1), p(type => 'Bar', name => 'b', named => 1)], 'hashref');
+
+    my $foo = sub { 'Foo' };
+    is(Sub::Meta::Parameters->_normalize_args(
+        { a => $foo }),
+        [p(type => $foo, name => 'a', named => 1)], 'hashref');
 };
 
 subtest 'invocant' => sub {

--- a/t/03_param.t
+++ b/t/03_param.t
@@ -5,6 +5,7 @@ use Sub::Meta::Param;
 subtest 'single arg' => sub {
     my $param = Sub::Meta::Param->new('Type');
     is $param->type, 'Type', 'type';
+    is $param->isa_, 'Type', 'isa';
     is $param->name, undef, 'name';
     is $param->default, undef, 'default';
     is $param->coerce, undef, 'coerce';
@@ -31,8 +32,13 @@ subtest 'setter' => sub {
 
     is $param->set_name('$foo'), $param, 'set_name';
     is $param->name, '$foo', 'name';
+
     is $param->set_type('Type'), $param, 'set_type';
     is $param->type, 'Type', 'type';
+    is $param->set_isa('Type2'), $param, 'set_isa';
+    is $param->isa_, 'Type2', 'type2';
+    is $param->type, 'Type2', 'type2';
+
     is $param->set_default('Default'), $param, 'set_default';
     is $param->default, 'Default', 'default';
     is $param->set_coerce('Coerce'), $param, 'set_coerce';


### PR DESCRIPTION
In the current version, the code is complicated to create a sub meta. e.g. [code for p5-Types-TypedCodeRef](https://github.com/ybrliiu/p5-Types-TypedCodeRef/blob/db14ba6f0fc3ffe0d98782ef44fce3713dfa2e67/lib/Types/TypedCodeRef.pm#L22-L52).
To solve this problem, make the constructor more flexible.
With this pull-request, the code to make a sub meta from TypedCodeRef will be as follows:

```perl
use Sub::Meta;
use Sub::WrapInType;
use Types::Standard -types;

my $code = wrap_sub [ Int, Int ], Int, sub { };
my $meta = Sub::Meta->new(
    args    => $code->params,
    returns => $code->returns,
);
```




- features:
    - args interface. e.g. `Sub::Meta->new(args => [])`
    - args can take hashref.
      e.g. `$parameters->set_args({ a => 'Str' })`
    - `isa` alias of `type`
      e.g. `$parameters->set_args([{ isa => 'Int' }])`

- BREAKING CHANGE:
    - args can't take a list. Instead use arrayref:
      NG: `$parameters->set_args(Int, Int)`
      OK: `$parameters->set_args([Int, Int])`

    - cannot be set to any object. Instead, use an object that inherits:
      NG: `$meta->set_parameters($anyobject)`
      OK: `$meta->set_parameters($sub_meta_parameters)`

      NG: `$meta->set_args([$anyobject])`
        NOTE: this $anyobject is treated as `type`: `{ type => $anyobject }`
      OK: `$meta->set_args([$sub_meta_param])`

- add methods:
    - Sub::Meta#args/set_args
    - Sub::Meta#nshift/set_nshift
    - Sub::Meta#slurpy/set_slurpy
    - Sub::Meta::Param#isa_/set_isa