### PR TITLE
fix: slurpy take Sub::Meta::Param

### DIFF
--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -324,7 +324,7 @@ Others are as follows:
     Sub::Meta->new(
         name      => 'twice',
         args      => [],
-        slurpy    => 1,
+        slurpy    => { name => '@numbers' },
         returns   => ArrayRef[Int],
     );
 

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -9,7 +9,6 @@ use Scalar::Util ();
 
 use overload
     fallback => 1,
-    '""'     => sub { $_[0]->name || '' },
     eq       =>  \&is_same_interface,
 ;
 
@@ -27,7 +26,7 @@ sub new {
 
     %args = (%DEFAULT, %args);
 
-    bless \%args => $class;
+    return bless \%args => $class;
 }
 
 sub name()       { $_[0]{name} }

--- a/t/01_meta.t
+++ b/t/01_meta.t
@@ -87,8 +87,8 @@ subtest 'has sub' => sub {
         is $meta->args, Sub::Meta::Parameters->new(args => ['Int'])->args, 'args';
         is $meta->set_nshift(1), $meta, 'set_nshift';
         is $meta->nshift, 1, 'nshift';
-        is $meta->set_slurpy(1), $meta, 'set_slurpy';
-        is $meta->slurpy, 1, 'slurpy';
+        is $meta->set_slurpy('Str'), $meta, 'set_slurpy';
+        is $meta->slurpy, Sub::Meta::Param->new('Str'), 'slurpy';
         is $meta->set_returns([]), $meta, 'set_returns';
         is $meta->returns, Sub::Meta::Returns->new([]), 'returns';
     };

--- a/t/02_parameters.t
+++ b/t/02_parameters.t
@@ -66,9 +66,9 @@ my @TEST = (
         args_min                 => 1,
         args_max                 => 1,
     ],
-    { args => [p(type => 'Foo')], nshift => 1, slurpy => 1 } => [
+    { args => [p(type => 'Foo')], nshift => 1, slurpy => 'Str' } => [
         nshift                   => 1,
-        slurpy                   => !!1,
+        slurpy                   => p(type => 'Str'),
         args                     => [p(type => 'Foo')],
         _all_positional_required => [p(type => 'Foo')],
         positional               => [],
@@ -130,9 +130,9 @@ my @TEST = (
         args_min                 => 0,
         args_max                 => 0 + 'Inf',
     ],
-    { args => [p(type => 'Foo', named => 1, optional => 1)], slurpy => 1 } => [
+    { args => [p(type => 'Foo', named => 1, optional => 1)], slurpy => 'Str' } => [
         nshift                   => 0,
-        slurpy                   => !!1,
+        slurpy                   => p(type => 'Str'),
         args                     => [p(type => 'Foo', named => 1, optional => 1)],
         _all_positional_required => [],
         positional               => [],
@@ -236,6 +236,7 @@ while (my ($parameters, $expect) = splice @TEST, 0, 2) {
 }
 
 subtest 'setter' => sub {
+    my $some = bless {}, 'Some';
     my $parameters = Sub::Meta::Parameters->new(args => [p()]);
 
     is $parameters->nshift, 0, 'nshift';
@@ -243,10 +244,12 @@ subtest 'setter' => sub {
     is $parameters->nshift, 1, 'nshift';
 
     ok !$parameters->slurpy, 'slurpy';
-    is $parameters->set_slurpy, $parameters, 'set_slurpy';
-    ok $parameters->slurpy, 'slurpy';
-    is $parameters->set_slurpy(0), $parameters, 'set_slurpy';
-    ok !$parameters->slurpy, 'slurpy';
+    is $parameters->set_slurpy('Str'), $parameters, 'set_slurpy';
+    is $parameters->slurpy, p(type => 'Str'), 'slurpy';
+    is $parameters->set_slurpy(p(type => 'Int')), $parameters, 'set_slurpy';
+    is $parameters->slurpy, p(type => 'Int'), 'slurpy';
+    is $parameters->set_slurpy($some), $parameters, 'set_slurpy';
+    is $parameters->slurpy, p(type => $some), 'slurpy';
 
     is $parameters->args, [p()], 'args';
     is $parameters->set_args([p(type => 'Foo')]), $parameters, 'set_args';

--- a/t/02_parameters/is_same_interface.t
+++ b/t/02_parameters/is_same_interface.t
@@ -63,6 +63,15 @@ my @TEST = (
     { args => [], slurpy => 1, nshift => 0 }, 'valid',
     ]},
 
+    # empty slurpy
+    { args => [], nshift => 0 } => {
+    NG => [
+    { args => [], slurpy => 'Str', nshift => 0 }, 'invalid slurpy',
+    ],
+    OK => [
+    { args => [], nshift => 0 }, 'valid',
+    ]},
+
     # nshift
     { args => [$p1], slurpy => 0, nshift => 1 } => {
     NG => [

--- a/t/03_param.t
+++ b/t/03_param.t
@@ -67,10 +67,7 @@ subtest 'setter' => sub {
 
 subtest 'overload' => sub {
     my $param = Sub::Meta::Param->new({ name => '$foo' });
-    is "$param", '$foo', 'overload string';
-
-    my $empty = Sub::Meta::Param->new({ });
-    is "$empty", '', 'overload no string';
+    ok $param eq $param;
 };
 
 subtest 'new' => sub {


### PR DESCRIPTION

In Function::Parameters, slurpy contains parameter information.
Sub::Meta::Parameters should also contain parameter information.

```perl
use Sub::Meta::Parameters;
use Types::Standard -types;

my $meta = Sub::Meta::Parameters->new(args => []);
$meta->set_slurpy({ name => '@numbers', type => Int });
$meta->slurpy; # => Sub::Meta::Param
```


### BREAKING CHANGE:
- stop overloading strings at Sub::Meta::Param