### PR TITLE
feat Sub::Meta::Creator, Sub::Meta::Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,31 @@ Sub::Meta->new(
 );
 ```
 
+Another way to create a Sub::Meta is to use [Sub::Meta::Creator](https://metacpan.org/pod/Sub%3A%3AMeta%3A%3ACreator):
+
+```perl
+use Sub::Meta::Creator;
+use Sub::Meta::Finder::FunctionParameters;
+
+my $creator = Sub::Meta::Creator->new(
+    finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ],
+);
+
+use Function::Parameters;
+use Types::Standard -types;
+
+method hello(Str $msg) { }
+my $meta = $creator->create(\&hello);
+# =>
+# Sub::Meta
+#   args [
+#       [0] Sub::Meta::Param->new(name => '$msg', type => Str)
+#   ],
+#   invocant   Sub::Meta::Param->(name => '$self', invocant => 1),
+#   nshift     1,
+#   slurpy     !!0
+```
+
 ## ACCESSORS
 
 ### sub

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -382,6 +382,29 @@ Others are as follows:
         returns   => Str,
     );
 
+Another way to create a Sub::Meta is to use L<Sub::Meta::Creator>:
+
+    use Sub::Meta::Creator;
+    use Sub::Meta::Finder::FunctionParameters;
+
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ],
+    );
+
+    use Function::Parameters;
+    use Types::Standard -types;
+
+    method hello(Str $msg) { }
+    my $meta = $creator->create(\&hello);
+    # =>
+    # Sub::Meta
+    #   args [
+    #       [0] Sub::Meta::Param->new(name => '$msg', type => Str)
+    #   ],
+    #   invocant   Sub::Meta::Param->(name => '$self', invocant => 1),
+    #   nshift     1,
+    #   slurpy     !!0
+
 =head2 ACCESSORS
 
 =head3 sub

--- a/lib/Sub/Meta/Creator.pm
+++ b/lib/Sub/Meta/Creator.pm
@@ -1,0 +1,139 @@
+package Sub::Meta::Creator;
+use strict;
+use warnings;
+
+our $VERSION = "0.07";
+
+use List::Util ();
+use Sub::Meta;
+
+sub _croak { require Carp; goto &Carp::croak }
+
+sub new {
+    my $class = shift;
+    my %args = @_ == 1 ? %{$_[0]} : @_;
+
+    unless (exists $args{finders}) {
+        _croak 'required finders';
+    }
+
+    unless (ref $args{finders} && ref $args{finders} eq 'ARRAY') {
+        _croak 'finders must be an arrayref'
+    }
+
+    unless (List::Util::all { ref $_ && ref $_ eq 'CODE' } @{$args{finders}}) {
+        _croak 'elements of finders have to be a code reference'
+    }
+
+    return bless \%args => $class;
+}
+
+sub sub_meta_class { 'Sub::Meta' }
+
+sub finders { $_[0]{finders} }
+
+sub find_materials {
+    my ($self, $sub) = @_;
+    for my $finder (@{$self->finders}) {
+        my $materials = $finder->($sub);
+        return $materials if defined $materials;
+    }
+    return;
+}
+
+sub create {
+    my ($self, $sub) = @_;
+    if (my $materials = $self->find_materials($sub)) {
+        return $self->sub_meta_class->new($materials)
+    }
+    return;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sub::Meta::Creator - creator of Sub::Meta by code reference
+
+=head1 SYNOPSIS
+
+    use Sub::Meta::Creator;
+
+    sub finder {
+        my $sub = shift;
+        return +{ sub => $sub }
+    }
+
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&finder ],
+    );
+
+    sub foo { }
+    my $meta = $creator->create(\&foo);
+
+=head1 DESCRIPTION
+
+This module provides convenient ways to create Sub::Meta.
+The purpose of this module is to make it easier to associate Sub::Meta with information of code references.
+For example, Function::Parameters can retrieve not only subroutine names and packages from code references,
+but also argument type information, etc. Sub::Meta::Creator can be generated Sub::Meta with such information:
+
+    use Sub::Meta::Creator;
+    use Sub::Meta::Finder::FunctionParameters;
+
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ]
+    );
+
+    use Function::Parameters;
+    use Types::Standard -types;
+
+    fun hello(Str $msg) { }
+    my $meta = $creator->create(\&hello);
+    my $args = $meta->args; # [ Sub::Meta::Param->new(name => '$msg', type => Str) ]
+
+=head1 METHODS
+
+=head2 new
+
+Constructor of C<Sub::Meta::Creator>. This constructor requires finders:
+    
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ sub { my $sub = shift; +{ sub => $sub } } ]
+    );
+
+=head2 finders
+
+Return elements of finder.
+The type of finders is C<ArrayRef[CodeRef]>.
+C<CodeRef>, an element of finders, finds information from the code reference of the first argument,
+processes the information to become the argument of C<Sub::Meta#new>, and returns it.
+
+=head2 find_materials($sub)
+
+From the code reference, find the material for C<Sub::Meta#new>.
+
+=head2 create($sub)
+
+From the code reference, create the instance of C<Sub::Meta>.
+
+=head2 sub_meta_class
+
+Returns class name of Sub::Meta. default: Sub::Meta
+Please override for customization.
+
+=head1 LICENSE
+
+Copyright (C) kfly8.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+kfly8 E<lt>kfly@cpan.orgE<gt>
+
+=cut

--- a/lib/Sub/Meta/Finder/FunctionParameters.pm
+++ b/lib/Sub/Meta/Finder/FunctionParameters.pm
@@ -1,0 +1,122 @@
+package Sub::Meta::Finder::FunctionParameters;
+use strict;
+use warnings;
+
+use Function::Parameters;
+
+sub find_materials {
+    my $sub = shift;
+
+    my $info = Function::Parameters::info($sub);
+    return unless $info;
+
+    my $keyword = $info->keyword;
+    my $nshift  = $info->nshift;
+
+    my @args;
+    for ($info->positional_required) {
+        push @args => {
+            type       => $_->type,
+            name       => $_->name,
+            positional => 1,
+            required   => 1,
+        }
+    }
+
+    for ($info->positional_optional) {
+        push @args => {
+            type       => $_->type,
+            name       => $_->name,
+            positional => 1,
+            required   => 0,
+        }
+    }
+
+    for ($info->named_required) {
+        push @args => {
+            type       => $_->type,
+            name       => $_->name,
+            named      => 1,
+            required   => 1,
+        }
+    }
+
+    for ($info->named_optional) {
+        push @args => {
+            type       => $_->type,
+            name       => $_->name,
+            named      => 1,
+            required   => 0,
+        }
+    }
+
+    my $invocant = $info->invocant ? +{
+        name => $info->invocant->name,
+        $info->invocant->type ? ( type => $info->invocant->type ) : (),
+    } : undef;
+
+    my $slurpy = $info->slurpy ? +{
+        name => $info->slurpy->name,
+        $info->slurpy->type ? ( type => $info->slurpy->type ) : (),
+    } : undef;
+
+    return +{
+        sub       => $sub,
+        is_method => $keyword eq 'method' ? !!1 : !!0,
+        parameters => {
+            args   => \@args,
+            nshift => $nshift,
+            $invocant ? ( invocant  => $invocant ) : (),
+            $slurpy ? ( slurpy => $slurpy ) : (),
+        }
+    }
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sub::Meta::Finder::FunctionParameters - finder of Function::Parameters
+
+=head1 SYNOPSIS
+    
+    use Sub::Meta::Creator;
+    use Sub::Meta::Finder::FunctionParameters;
+
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ],
+    );
+
+    use Function::Parameters;
+    use Types::Standard -types;
+
+    method hello(Str $msg) { }
+    my $meta = $creator->create(\&hello);
+    # =>
+    # Sub::Meta
+    #   args [
+    #       [0] Sub::Meta::Param->new(name => '$msg', type => Str)
+    #   ],
+    #   invocant   Sub::Meta::Param->(name => '$self', invocant => 1),
+    #   nshift     1,
+    #   slurpy     !!0
+
+=head1 FUNCTIONS
+
+=head2 find_materials($sub)
+
+=head1 LICENSE
+
+Copyright (C) kfly8.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+kfly8 E<lt>kfly@cpan.orgE<gt>
+
+=cut

--- a/lib/Sub/Meta/Finder/SubWrapInType.pm
+++ b/lib/Sub/Meta/Finder/SubWrapInType.pm
@@ -1,0 +1,73 @@
+package Sub::Meta::Finder::SubWrapInType;
+use strict;
+use warnings;
+
+use Scalar::Util ();
+
+sub find_materials {
+    my $sub = shift;
+
+    return unless Scalar::Util::blessed($sub) && $sub->isa('Sub::WrapInType');
+
+    return {
+        sub       => $sub,
+        args      => $sub->params,
+        returns   => $sub->returns,
+        is_method => $sub->is_method,
+    }
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sub::Meta::Finder::SubWrapInType - finder of Sub::WrapInType
+
+=head1 SYNOPSIS
+
+    use Sub::Meta::Creator;
+    use Sub::Meta::Finder::SubWrapInType;
+
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::SubWrapInType::find_materials ],
+    );
+
+    use Sub::WrapInType;
+    use Types::Standard -types;
+
+    my $foo = wrap_method [Int, Int] => Int, sub { };
+    my $meta = $creator->create($foo);
+    # =>
+    # Sub::Meta
+    #   args [
+    #       [0] Sub::Meta::Param->new(type => Int),
+    #       [1] Sub::Meta::Param->new(type => Int),
+    #   ],
+    #   returns {
+    #       list   => Int,
+    #       scalar => Int,
+    #   }
+    #   invocant   Sub::Meta::Param->(invocant => 1),
+    #   nshift     1,
+    #   slurpy     !!0
+
+
+=head1 FUNCTIONS
+
+=head2 find_materials
+
+=head1 LICENSE
+
+Copyright (C) kfly8.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+kfly8 E<lt>kfly@cpan.orgE<gt>
+
+=cut

--- a/t/07_creator.t
+++ b/t/07_creator.t
@@ -1,0 +1,71 @@
+use Test2::V0;
+
+use Sub::Meta::Creator;
+
+sub finder {
+    my $sub = shift;
+    return { sub => $sub };
+}
+
+subtest 'new' => sub {
+    like dies { Sub::Meta::Creator->new() }, qr/^required finders/;
+    like dies { Sub::Meta::Creator->new(finders => '') }, qr/^finders must be an arrayref/;
+    like dies { Sub::Meta::Creator->new(finders => {}) }, qr/^finders must be an arrayref/;
+    like dies { Sub::Meta::Creator->new(finders => ['']) }, qr/^elements of finders have to be a code reference/;
+    like dies { Sub::Meta::Creator->new(finders => [{}]) }, qr/^elements of finders have to be a code reference/;
+
+    my $creator = Sub::Meta::Creator->new(finders => [ \&finder ]);
+    isa_ok $creator, 'Sub::Meta::Creator';
+
+    subtest 'create by hashref' => sub {
+        my $creator = Sub::Meta::Creator->new({ finders => [ \&finder ] });
+        isa_ok $creator, 'Sub::Meta::Creator';
+    };
+};
+
+subtest 'accessors' => sub {
+    my $creator = Sub::Meta::Creator->new(finders => [ \&finder ]);
+
+    is $creator->sub_meta_class, 'Sub::Meta';
+    is $creator->finders, [ \&finder ];
+};
+
+subtest 'find_materials' => sub {
+    subtest 'finders is empty list' => sub {
+        my $creator = Sub::Meta::Creator->new(finders => [ ]);
+        is $creator->find_materials(sub {}), undef;
+    };
+
+    subtest 'empty finder' => sub {
+        my $creator = Sub::Meta::Creator->new(finders => [ sub {} ]);
+        is $creator->find_materials(sub {}), undef;
+    };
+
+    subtest 'one finder' => sub {
+        my $code = sub {};
+        my $creator = Sub::Meta::Creator->new(finders => [ sub { +{ hello => $_[0] } } ]);
+        is $creator->find_materials($code), { hello => $code };
+    };
+
+    subtest 'multi finder' => sub {
+        my $code = sub {};
+        my $creator = Sub::Meta::Creator->new(finders => [ sub {}, sub { +{ sub => $_[0] } } ]);
+        is $creator->find_materials($code), { sub => $code };
+    };
+};
+
+subtest 'create' => sub {
+    subtest 'empty finder' => sub {
+        my $code = sub {};
+        my $creator = Sub::Meta::Creator->new(finders => [ sub {} ]);
+        is $creator->create($code), undef;
+    };
+
+    subtest 'finder' => sub {
+        my $code = sub {};
+        my $creator = Sub::Meta::Creator->new(finders => [ sub { +{ subname => 'hello' } } ]);
+        is $creator->create($code), Sub::Meta->new(subname => 'hello');
+    };
+};
+
+done_testing;

--- a/t/08_finders/function_parameters.t
+++ b/t/08_finders/function_parameters.t
@@ -1,0 +1,262 @@
+use Test2::V0;
+use Test2::Require::Module 'Function::Parameters';
+
+use Function::Parameters;
+
+use Sub::Meta::Creator;
+use Sub::Meta::Finder::FunctionParameters;
+
+sub find_materials { goto &Sub::Meta::Finder::FunctionParameters::find_materials }
+sub param { Sub::Meta::Param->new(@_) }
+
+sub Str() { bless {}, 'SomeStr' }
+sub Int() { bless {}, 'SomeInt' }
+
+sub not_function_paramters {};
+fun case_fun_positional(Str $a) {};
+fun case_fun_positional_optional(Str $a='aaa') {};
+fun case_fun_named(Str :$a) {};
+fun case_fun_named_optional(Str :$a='aaa') {};
+fun case_fun_positional_and_optional(Str $a, Int $b=123) {};
+fun case_fun_slurpy(@args) {};
+fun case_fun_slurpy_with_type(Str @args) {};
+method case_method() {}
+method case_class_method($class: ) {}
+method case_class_method_with_type(Str $class: ) {}
+
+subtest 'find_materials' => sub {
+    is find_materials(\&not_function_paramters), undef, 'not_function_paramters';
+    is find_materials(\&case_fun_positional), {
+        sub       => \&case_fun_positional,
+        is_method => !!0,
+        parameters => {
+            args   => [ { type => Str, name => '$a', positional => 1, required => 1 } ],
+            nshift => 0,
+        },
+    }, 'case_fun_positional';
+
+    is find_materials(\&case_fun_positional_optional), {
+        sub       => \&case_fun_positional_optional,
+        is_method => !!0,
+        parameters => {
+            args   => [ { type => Str, name => '$a', positional => 1, required => 0 } ],
+            nshift => 0,
+        },
+    }, 'case_fun_positional_optional';
+    
+    is find_materials(\&case_fun_named), {
+        sub       => \&case_fun_named,
+        is_method => !!0,
+        parameters => {
+            args   => [ { type => Str, name => '$a', named => 1, required => 1 } ],
+            nshift => 0,
+        },
+    }, 'case_fun_named';
+
+    is find_materials(\&case_fun_named_optional), {
+        sub       => \&case_fun_named_optional,
+        is_method => !!0,
+        parameters => {
+            args   => [ { type => Str, name => '$a', named => 1, required => 0 } ],
+            nshift => 0,
+        },
+    }, 'case_fun_named_optional';
+
+    is find_materials(\&case_fun_positional_and_optional), {
+        sub       => \&case_fun_positional_and_optional,
+        is_method => !!0,
+        parameters => {
+            args   => [
+                { type => Str, name => '$a', positional => 1, required => 1 },
+                { type => Int, name => '$b', positional => 1, required => 0 },
+            ],
+            nshift => 0,
+        },
+    }, 'case_fun_positional_and_optional';
+
+    is find_materials(\&case_fun_slurpy), {
+        sub       => \&case_fun_slurpy,
+        is_method => !!0,
+        parameters => {
+            args   => [  ],
+            nshift => 0,
+            slurpy => { name => '@args' },
+        },
+    }, 'case_fun_slurpy';
+
+    is find_materials(\&case_fun_slurpy_with_type), {
+        sub       => \&case_fun_slurpy_with_type,
+        is_method => !!0,
+        parameters => {
+            args   => [  ],
+            nshift => 0,
+            slurpy => { name => '@args', type => Str },
+        },
+    }, 'case_fun_slurpy_with_type';
+
+    is find_materials(\&case_method), {
+        sub       => \&case_method,
+        is_method => !!1,
+        parameters => {
+            args   => [ ],
+            nshift => 1,
+            invocant => { name => '$self' },
+        },
+    }, 'case_method';
+
+    is find_materials(\&case_class_method), {
+        sub       => \&case_class_method,
+        is_method => !!1,
+        parameters => {
+            args   => [ ],
+            nshift => 1,
+            invocant => { name => '$class' },
+        },
+    }, 'case_class_method';
+
+    is find_materials(\&case_class_method_with_type), {
+        sub       => \&case_class_method_with_type,
+        is_method => !!1,
+        parameters => {
+            args   => [ ],
+            nshift => 1,
+            invocant => { name => '$class', type => Str },
+        },
+    }, 'case_class_method_with_type';
+};
+
+subtest 'create' => sub {
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ],
+    );
+
+    subtest 'not_function_paramters' => sub {
+        is $creator->create(\&not_function_paramters), undef, 'not_function_paramters';
+    };
+
+    subtest 'case_fun_positional' => sub {
+        my $sub = \&case_fun_positional;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ param(type => Str, name => '$a', positional => 1, required => 1) ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_fun_positional_optional' => sub {
+        my $sub = \&case_fun_positional_optional;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ param(type => Str, name => '$a', positional => 1, required => 0) ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_fun_named' => sub {
+        my $sub = \&case_fun_named;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ param(type => Str, name => '$a', named => 1, required => 1) ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_fun_named_optional' => sub {
+        my $sub = \&case_fun_named_optional;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ param(type => Str, name => '$a', named => 1, required => 0) ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_fun_positional_and_optional' => sub {
+        my $sub = \&case_fun_positional_and_optional;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [
+            param(type => Str, name => '$a', positional => 1, required => 1),
+            param(type => Str, name => '$b', positional => 1, required => 0),
+        ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_fun_slurpy' => sub {
+        my $sub = \&case_fun_slurpy;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        is $meta->slurpy, param(name => '@args'), 'slurpy';
+    };
+
+    subtest 'case_fun_slurpy_with_type' => sub {
+        my $sub = \&case_fun_slurpy_with_type;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is $meta->args, [ ], 'args';
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        is $meta->slurpy, param(type => Str, name => '@args'), 'slurpy';
+    };
+
+    subtest 'case_method' => sub {
+        my $sub = \&case_method;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!1, 'is_method';
+        is $meta->args, [ ], 'args';
+        is $meta->nshift, 1, 'nshift';
+        is $meta->invocant, param(name => '$self', invocant => 1), 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_class_method' => sub {
+        my $sub = \&case_class_method;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!1, 'is_method';
+        is $meta->args, [ ], 'args';
+        is $meta->nshift, 1, 'nshift';
+        is $meta->invocant, param(name => '$class', invocant => 1), 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_class_method_with_type' => sub {
+        my $sub = \&case_class_method_with_type;
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!1, 'is_method';
+        is $meta->args, [ ], 'args';
+        is $meta->nshift, 1, 'nshift';
+        is $meta->invocant, param(name => '$class', type => Str, invocant => 1), 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+};
+
+done_testing;

--- a/t/08_finders/sub_wrap_in_type.t
+++ b/t/08_finders/sub_wrap_in_type.t
@@ -1,0 +1,114 @@
+use Test2::V0;
+use Test2::Require::Module 'Sub::WrapInType', '0.04';
+use Test2::Require::Module 'Types::Standard';
+
+use Sub::WrapInType;
+use Types::Standard -types;
+
+use Sub::Meta::Creator;
+use Sub::Meta::Finder::SubWrapInType;
+
+subtest 'create' => sub {
+    my $creator = Sub::Meta::Creator->new(
+        finders => [ \&Sub::Meta::Finder::SubWrapInType::find_materials ],
+    );
+
+    subtest 'not_sub_wrap_in_type' => sub {
+        is $creator->create(sub { }), undef, 'not_sub_wrap_in_type';
+        is $creator->create(bless sub {}, 'Some'), undef, 'not_sub_wrap_in_type';
+    };
+
+    subtest 'case_positional' => sub {
+        my $sub = wrap_sub [Str] => Str, sub {};
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+        is scalar @{$meta->args}, 1;
+
+        note 'args';
+        ok $meta->args->[0]->type == Str;
+        ok $meta->args->[0]->positional;
+        ok $meta->args->[0]->required;
+
+        note 'returns';
+        ok $meta->returns->list == Str;
+        ok $meta->returns->scalar == Str;
+
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_named' => sub {
+        my $sub = wrap_sub { a => Str } => Str, sub {};
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!0, 'is_method';
+
+        note 'args'; 
+        is scalar @{$meta->args}, 1;
+        ok $meta->args->[0]->type == Str;
+        ok $meta->args->[0]->named;
+        ok $meta->args->[0]->required;
+        is $meta->args->[0]->name, 'a';
+
+        note 'returns'; 
+        ok $meta->returns->list == Str;
+        ok $meta->returns->scalar == Str;
+
+        is $meta->nshift, 0, 'nshift';
+        ok !$meta->invocant, 'invocant';
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_method_positional' => sub {
+        my $sub = wrap_method [Str] => Str, sub {};
+
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!1, 'is_method';
+
+        note 'args';
+        is scalar @{$meta->args}, 1;
+        ok $meta->args->[0]->type == Str;
+        ok $meta->args->[0]->positional;
+        ok $meta->args->[0]->required;
+
+        note 'returns';
+        ok $meta->returns->list == Str;
+        ok $meta->returns->scalar == Str;
+
+        is $meta->nshift, 1, 'nshift';
+        isa_ok $meta->invocant, 'Sub::Meta::Param';
+        ok $meta->invocant->invocant;
+        ok !$meta->slurpy, 'slurpy';
+    };
+
+    subtest 'case_method_named' => sub {
+        my $sub = wrap_method { a => Str } => Str, sub {};
+    
+        my $meta = $creator->create($sub);
+        is $meta->sub, $sub, 'sub';
+        is $meta->is_method, !!1, 'is_method';
+
+        note 'args';
+        is scalar @{$meta->args}, 1;
+        ok $meta->args->[0]->type == Str;
+        ok $meta->args->[0]->named;
+        ok $meta->args->[0]->required;
+        is $meta->args->[0]->name, 'a';
+
+        note 'returns';
+        ok $meta->returns->list == Str;
+        ok $meta->returns->scalar == Str;
+
+        is $meta->nshift, 1, 'nshift';
+        isa_ok $meta->invocant, 'Sub::Meta::Param';
+        ok $meta->invocant->invocant;
+        ok !$meta->slurpy, 'slurpy';
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Sub::Meta::Creator provides convenient ways to create Sub::Meta.
The purpose of this module is to make it easier to associate Sub::Meta with information of code references.
For example, Function::Parameters can retrieve not only subroutine names and packages from code references,
but also argument type information, etc. Sub::Meta::Creator can be generated Sub::Meta with such information:

```perl
use Sub::Meta::Creator;
use Sub::Meta::Finder::FunctionParameters;

my $creator = Sub::Meta::Creator->new(
    finders => [ \&Sub::Meta::Finder::FunctionParameters::find_materials ]
);

use Function::Parameters;
use Types::Standard -types;

fun hello(Str $msg) { }
my $meta = $creator->create(\&hello);
my $args = $meta->args; # [ Sub::Meta::Param->new(name => '$msg', type => Str) ]
```