### PR TITLE
feat : display of Sub::Meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $meta->attribute   # ['method']
 $meta->is_method   # undef
 $meta->parameters  # undef
 $meta->returns     # undef
+$meta->display     # 'sub hello'
 
 # setter
 $meta->set_subname('world');
@@ -355,7 +356,7 @@ $meta->set_returns(Sub::Meta::Returns->new(type => 'Foo'));
 $meta->set_returns(MyReturns->new)
 ```
 
-## OTHERS
+## METHODS
 
 ### is\_same\_interface($other\_meta)
 
@@ -380,6 +381,24 @@ my $check = eval "sub { $inline }";
 $check->(Sub::Meta->new(subname => 'hello')); # => OK
 $check->(Sub::Meta->new(subname => 'world')); # => NG
 ```
+
+### display
+
+Returns the display of Sub::Meta:
+
+```perl
+use Sub::Meta;
+use Types::Standard qw(Str);
+my $meta = Sub::Meta->new(
+    subname => 'hello',
+    is_method => 1,
+    args => [Str],
+    returns => Str,
+);
+$meta->display;  # 'method hello(Str) => Str'
+```
+
+## OTHERS
 
 ### parameters\_class
 

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -330,6 +330,7 @@ Sub::Meta - handle subroutine meta information
     $meta->is_method   # undef
     $meta->parameters  # undef
     $meta->returns     # undef
+    $meta->display     # 'sub hello'
 
     # setter
     $meta->set_subname('world');
@@ -640,7 +641,7 @@ Sets the returns object of L<Sub::Meta::Returns> or any object.
     $meta->set_returns(Sub::Meta::Returns->new(type => 'Foo'));
     $meta->set_returns(MyReturns->new)
 
-=head2 OTHERS
+=head2 METHODS
 
 =head3 is_same_interface($other_meta)
 
@@ -663,6 +664,22 @@ Returns inlined C<is_same_interface> string:
     my $check = eval "sub { $inline }";
     $check->(Sub::Meta->new(subname => 'hello')); # => OK
     $check->(Sub::Meta->new(subname => 'world')); # => NG
+
+=head3 display
+
+Returns the display of Sub::Meta:
+
+    use Sub::Meta;
+    use Types::Standard qw(Str);
+    my $meta = Sub::Meta->new(
+        subname => 'hello',
+        is_method => 1,
+        args => [Str],
+        returns => Str,
+    );
+    $meta->display;  # 'method hello(Str) => Str'
+
+=head2 OTHERS
 
 =head3 parameters_class
 

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -288,6 +288,18 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
+sub display {
+    my $self = shift;
+
+    my $keyword = $self->is_method ? 'method' : 'sub';
+    my $subname = $self->subname // '';
+
+    my $s = $keyword;
+    $s .= ' ' . $subname if $subname;
+    $s .= '('. $self->parameters->display .')' if $self->parameters;
+    $s .= ' => ' . $self->returns->display if $self->returns;
+    return $s;
+}
 
 1;
 __END__

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -93,6 +93,17 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
+sub display {
+    my $self = shift;
+
+    my $s = '';
+    $s .= $self->type if $self->type;
+    $s .= ' ' if $s && $self->name;
+    $s .= ':' if $self->named;
+    $s .= $self->name if $self->name;
+    return $s;
+}
+
 
 1;
 __END__

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -236,7 +236,7 @@ A boolean value indicating whether to be invocant. Default to false.
 
 Setter for C<invocant>.
 
-=head2 OTHERS
+=head2 METHODS
 
 =head3 is_same_interface($other_meta)
 
@@ -246,6 +246,18 @@ Specifically, check whether C<name>, C<type>, C<optional> and C<named> are equal
 =head3 is_same_interface_inlined($other_meta_inlined)
 
 Returns inlined C<is_same_interface> string.
+
+=head3 display
+
+Returns the display of Sub::Meta::Param:
+
+    use Sub::Meta::Param;
+    use Types::Standard qw(Str);
+    my $meta = Sub::Meta::Param->new(
+        type => Str,
+        name => '$message',
+    );
+    $meta->display;  # 'Str $message'
 
 =head1 SEE ALSO
 

--- a/lib/Sub/Meta/Parameters.pm
+++ b/lib/Sub/Meta/Parameters.pm
@@ -198,6 +198,19 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
+sub display {
+    my $self = shift;
+
+    my $s = '';
+    $s .= $self->invocant->display . ': '
+        if $self->invocant && $self->invocant->display;
+
+    $s .= join ', ', map { $_->display } @{$self->args};
+    $s .= ', ' if $s && $self->slurpy;
+    $s .= $self->slurpy->display if $self->slurpy;
+    return $s;
+}
+
 1;
 __END__
 

--- a/lib/Sub/Meta/Parameters.pm
+++ b/lib/Sub/Meta/Parameters.pm
@@ -388,16 +388,32 @@ This is computed as follows:
   If there are any named or slurpy parameters, the result is Inf.
   Otherwise the result is the number of all invocants and positional parameters.
 
+=head2 METHODS
+
 =head3 is_same_interface($other_meta)
 
 A boolean value indicating whether C<Sub::Meta::Parameters> object is same or not.
 Specifically, check whether C<args>, C<nshift> and C<slurpy> are equal.
 
-=head2 OTHERS
-
 =head3 is_same_interface_inlined($other_meta_inlined)
 
 Returns inlined C<is_same_interface> string.
+
+=head3 display
+
+Returns the display of Sub::Meta::Parameters:
+
+    use Sub::Meta::Parameters;
+    use Types::Standard qw(Num);
+    my $meta = Sub::Meta::Parameters->new(
+        args => [
+            { name => '$lat', type => Num, named => 1 },
+            { name => '$lng', type => Num, named => 1 },
+        ],
+    );
+    $meta->display; # 'Num :$lat, Num :$lng'
+
+=head2 OTHERS
 
 =head3 param_class
 

--- a/lib/Sub/Meta/Returns.pm
+++ b/lib/Sub/Meta/Returns.pm
@@ -179,7 +179,7 @@ A boolean whether with coercions.
 
 Setter for C<coerce>.
 
-=head2 OTHERS
+=head2 METHODS
 
 =head3 is_same_interface($other_meta)
 
@@ -189,6 +189,15 @@ Specifically, check whether C<scalar>, C<list> and C<void> are equal.
 =head3 is_same_interface_inlined($other_meta_inlined)
 
 Returns inlined C<is_same_interface> string.
+
+=head3 display
+
+Returns the display of Sub::Meta::Returns:
+
+    use Sub::Meta::Returns;
+    use Types::Standard qw(Tuple Str);
+    my $meta = Sub::Meta::Returns->new(Tuple[Str,Str]);
+    $meta->display; # 'Tuple[Str,Str]'
 
 =head1 LICENSE
 

--- a/lib/Sub/Meta/Returns.pm
+++ b/lib/Sub/Meta/Returns.pm
@@ -102,6 +102,18 @@ sub _eq_inlined {
     return join "\n && ", @src;
 }
 
+sub display {
+    my $self = shift;
+
+    if (_eq($self->scalar, $self->list) && _eq($self->list, $self->void)) {
+        return $self->scalar . '';
+    }
+    else {
+        my @r = map { $self->$_ ? "$_ => @{[$self->$_]}" : () } qw(scalar list void);
+        return "(@{[join ', ', @r]})";
+    }
+}
+
 1;
 __END__
 

--- a/t/01_meta/new.t
+++ b/t/01_meta/new.t
@@ -7,14 +7,29 @@ use JSON::PP;
 my $json = JSON::PP->new->allow_nonref->convert_blessed->canonical;
 
 subtest 'args: parameters' => sub {
-    my $meta = Sub::Meta->new(
-        parameters => { args => ['Str'] },
-    );
-    is $meta->parameters, Sub::Meta::Parameters->new(args => ['Str']);
+    subtest "{ args => ['Str'] }" => sub {
+        my $parameters = { args => ['Str'] };
+        my $meta = Sub::Meta->new(parameters => $parameters);
+        is $meta->parameters, Sub::Meta::Parameters->new($parameters);
+        ok !$meta->is_method;
+    };
+
+    subtest "{ args => ['Str'], nshift => 1 }" => sub {
+        my $parameters = { args => ['Str'], nshift => 1 };
+        my $meta = Sub::Meta->new(parameters => $parameters);
+        is $meta->parameters, Sub::Meta::Parameters->new($parameters);
+        ok $meta->is_method;
+    };
+
+    subtest "{ args => ['Str'], invocant => { name => 'class' } }" => sub {
+        my $parameters = { args => ['Str'], invocant => { name => 'class' } };
+        my $meta = Sub::Meta->new(parameters => $parameters);
+        is $meta->parameters, Sub::Meta::Parameters->new($parameters);
+        ok $meta->is_method;
+    };
 };
 
 subtest 'args: args' => sub {
-
     my $check = sub {
         my ($a, $b) = @_;
         my $meta = Sub::Meta->new($a);
@@ -25,9 +40,14 @@ subtest 'args: args' => sub {
     $check->({args => ['Str']}, {args => ['Str']});
     $check->({args => ['Str'], slurpy => 1}, {args => ['Str'], slurpy => 1});
     $check->({args => ['Str'], nshift => 1}, {args => ['Str'], nshift => 1});
-    $check->({args => ['Str'], is_method => 1}, {args => ['Str'], nshift => 1}, 'if is_method flag is set, then set nshift to 1' );
+
+    $check->({args => ['Str'], is_method => 1}, {args => ['Str'], nshift => 1},
+            'if is_method flag is set, then set nshift to 1' );
     $check->({args => ['Str'], is_method => 0}, {args => ['Str'], nshift => 0});
     $check->({args => ['Str'], nshift => 1, is_method => 0}, {args => ['Str'], nshift => 1}, 'nshift has priority');
+
+    $check->({args => ['Str'], invocant => { name => '$class' }}, {args => ['Str'], nshift => 1, invocant => { name => '$class' }},
+            'if invocant is set, then set nshift to 1' );
 };
 
 done_testing;

--- a/t/09_display.t
+++ b/t/09_display.t
@@ -1,0 +1,67 @@
+use Test2::V0;
+
+use Sub::Meta;
+use Types::Standard -types;
+
+sub display { Sub::Meta->new(@_)->display }
+
+is display(), 'sub';
+is display(is_method => 1), 'method';
+is display(subname => 'hello'), 'sub hello';
+is display(subname => 'hello', is_method => 1), 'method hello';
+is display(subname => 'hello', args => [Str]), 'sub hello(Str)';
+is display(subname => 'hello', args => [Str, Int]), 'sub hello(Str, Int)';
+is display(
+    subname => 'hello',
+    args => [{ type => Str, name => '$a' }]
+   ), 'sub hello(Str $a)';
+
+is display(
+    subname => 'hello',
+    args => [{ type => Str, name => '$a' }, { type => Int, name => '$i', named => !!1 }]
+   ), 'sub hello(Str $a, Int :$i)';
+
+is display(
+    subname => 'hello',
+    is_method => 1,
+    args => [{ type => Str, name => '$a' }]
+   ), 'method hello(Str $a)';
+
+is display(
+    subname => 'hello',
+    invocant => { name => '$class' },
+    args => [{ type => Str, name => '$a' }]
+   ), 'method hello($class: Str $a)';
+
+is display(
+    subname => 'hello',
+    slurpy => { name => '@values' },
+    args => [{ type => Str, name => '$a' }]
+   ), 'sub hello(Str $a, @values)';
+
+
+is display(
+    subname => 'hello',
+    slurpy => { name => '@values' },
+    args => []
+   ), 'sub hello(@values)';
+
+is display(
+    subname => 'hello',
+    args => [],
+    returns => Int,
+   ), 'sub hello() => Int';
+
+is display(
+    subname => 'hello',
+    args => [],
+    returns => { scalar => Int, list => Str },
+   ), 'sub hello() => (scalar => Int, list => Str)';
+
+is display(
+    subname => 'hello',
+    args => [],
+    returns => { scalar => Int, list => Int, void => Str },
+   ), 'sub hello() => (scalar => Int, list => Int, void => Str)';
+
+done_testing;

--- a/t/09_display.t
+++ b/t/09_display.t
@@ -1,7 +1,6 @@
 use Test2::V0;
 
 use Sub::Meta;
-use Types::Standard -types;
 
 sub display { Sub::Meta->new(@_)->display }
 
@@ -9,34 +8,34 @@ is display(), 'sub';
 is display(is_method => 1), 'method';
 is display(subname => 'hello'), 'sub hello';
 is display(subname => 'hello', is_method => 1), 'method hello';
-is display(subname => 'hello', args => [Str]), 'sub hello(Str)';
-is display(subname => 'hello', args => [Str, Int]), 'sub hello(Str, Int)';
+is display(subname => 'hello', args => ['Str']), 'sub hello(Str)';
+is display(subname => 'hello', args => ['Str', 'Int']), 'sub hello(Str, Int)';
 is display(
     subname => 'hello',
-    args => [{ type => Str, name => '$a' }]
+    args => [{ type => 'Str', name => '$a' }]
    ), 'sub hello(Str $a)';
 
 is display(
     subname => 'hello',
-    args => [{ type => Str, name => '$a' }, { type => Int, name => '$i', named => !!1 }]
+    args => [{ type => 'Str', name => '$a' }, { type => 'Int', name => '$i', named => !!1 }]
    ), 'sub hello(Str $a, Int :$i)';
 
 is display(
     subname => 'hello',
     is_method => 1,
-    args => [{ type => Str, name => '$a' }]
+    args => [{ type => 'Str', name => '$a' }]
    ), 'method hello(Str $a)';
 
 is display(
     subname => 'hello',
     invocant => { name => '$class' },
-    args => [{ type => Str, name => '$a' }]
+    args => [{ type => 'Str', name => '$a' }]
    ), 'method hello($class: Str $a)';
 
 is display(
     subname => 'hello',
     slurpy => { name => '@values' },
-    args => [{ type => Str, name => '$a' }]
+    args => [{ type => 'Str', name => '$a' }]
    ), 'sub hello(Str $a, @values)';
 
 
@@ -49,19 +48,19 @@ is display(
 is display(
     subname => 'hello',
     args => [],
-    returns => Int,
+    returns => 'Int',
    ), 'sub hello() => Int';
 
 is display(
     subname => 'hello',
     args => [],
-    returns => { scalar => Int, list => Str },
+    returns => { scalar => 'Int', list => 'Str' },
    ), 'sub hello() => (scalar => Int, list => Str)';
 
 is display(
     subname => 'hello',
     args => [],
-    returns => { scalar => Int, list => Int, void => Str },
+    returns => { scalar => 'Int', list => 'Int', void => 'Str' },
    ), 'sub hello() => (scalar => Int, list => Int, void => Str)';
 
 done_testing;


### PR DESCRIPTION
Returns the display of Sub::Meta:

```perl
    use Sub::Meta;
    use Types::Standard qw(Str);
    my $meta = Sub::Meta->new(
        subname => 'hello',
        is_method => 1,
        args => [Str],
        returns => Str,
    );
    $meta->display;  # 'method hello(Str) => Str'
 ```


