### PR TITLE
improve: Sub::Meta::Param tests

### DIFF
--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -31,7 +31,7 @@ sub new {
 }
 
 sub name()       { my $self = shift; return $self->{name} // '' }
-sub type()       { my $self = shift; return $self->{type} // '' }
+sub type()       { my $self = shift; return $self->{type} }
 sub default()    { my $self = shift; return $self->{default} } ## no critic (ProhibitBuiltinHomonyms)
 sub coerce()     { my $self = shift; return $self->{coerce} }
 sub optional()   { my $self = shift; return !!$self->{optional} }
@@ -75,7 +75,7 @@ sub is_same_interface {
     }
 
     if ($self->has_type) {
-        return unless $self->type eq $other->type
+        return unless $self->type eq ($other->type // '');
     }
     else {
         return if $other->has_type
@@ -97,7 +97,7 @@ sub is_same_interface_inlined {
     push @src => $self->has_name ? sprintf("'%s' eq %s->name", $self->name, $v)
                                  : sprintf('!%s->has_name', $v);
 
-    push @src => $self->has_type ? sprintf("'%s' eq %s->type", "@{[$self->type]}", $v)
+    push @src => $self->has_type ? sprintf("'%s' eq (%s->type // '')", "@{[$self->type]}", $v)
                                  : sprintf('!%s->has_type', $v);
 
     push @src => sprintf("'%s' eq %s->optional", $self->optional, $v);

--- a/lib/Sub/Meta/Test.pm
+++ b/lib/Sub/Meta/Test.pm
@@ -2,7 +2,7 @@ package Sub::Meta::Test;
 use strict;
 use warnings;
 use parent qw(Exporter);
-our @EXPORT_OK = qw(test_submeta test_submeta_parameters);
+our @EXPORT_OK = qw(test_submeta test_submeta_parameters test_submeta_param);
 
 use Test2::API qw(context);
 use Test2::V0;
@@ -66,6 +66,32 @@ sub test_submeta_parameters {
     is $meta->has_slurpy               => !!$expected->{slurpy}                 // !!0,    'has_slurpy';
     is $meta->has_invocant             => !!$expected->{invocant}               // !!0,    'has_invocant';
  
+    $ctx->release;
+    return;
+}
+
+sub test_submeta_param {
+    my ($meta, $expected) = @_;
+    $expected //= {};
+
+    my $ctx = context;
+    isa_ok $meta, 'Sub::Meta::Param';
+    is $meta->name         => $expected->{name} // '',       'name';
+    is $meta->type         => $expected->{type},             'type';
+    is $meta->isa_         => $expected->{type},             'isa_';
+    is $meta->default      => $expected->{default},          'default';
+    is $meta->coerce       => $expected->{coerce},           'coerce';
+    is $meta->optional     => $expected->{optional} // !!0,  'optional';
+    is $meta->required     => !$expected->{optional},        'required';
+    is $meta->named        => $expected->{named}    // !!0,  'named';
+    is $meta->positional   => !$expected->{named},           'positional';
+    is $meta->invocant     => $expected->{invocant} // !!0,  'invocant';
+
+    is $meta->has_name     => !!$expected->{name},      'has_name';
+    is $meta->has_type     => !!$expected->{type},      'has_type';
+    is $meta->has_default  => !!$expected->{default},   'has_default';
+    is $meta->has_coerce   => !!$expected->{coerce},    'has_coerce';
+
     $ctx->release;
     return;
 }

--- a/t/20-unit/Sub-Meta-Param/basic.t
+++ b/t/20-unit/Sub-Meta-Param/basic.t
@@ -1,100 +1,111 @@
 use Test2::V0;
 
 use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
 
-subtest 'single arg' => sub {
-    my $param = Sub::Meta::Param->new('Type');
-    is $param->type, 'Type', 'type';
-    is $param->isa_, 'Type', 'isa';
-    is $param->name, '', 'name';
-    is $param->default, undef, 'default';
-    is $param->coerce, undef, 'coerce';
-    ok $param->positional, 'positional';
-    ok !$param->named, 'named';
-    ok $param->required, 'required';
-    ok !$param->optional, 'optional';
-    ok !$param->invocant, 'not invocant';
-    ok !$param->has_name;
-    ok $param->has_type;
-    ok !$param->has_default;
-    ok !$param->has_coerce;
+subtest 'arg: type => Str' => sub {
+    my $param = Sub::Meta::Param->new({ type => 'Str' });
+    test_submeta_param($param, {
+        type => 'Str',
+    });
 };
 
-subtest 'hashref arg' => sub {
-    my $param = Sub::Meta::Param->new({ type => 'Type', name => 'foo', named => 1, optional => 1, default => 999 });
-    is $param->type, 'Type', 'type';
-    is $param->name, 'foo', 'name';
-    is $param->default, 999, 'default';
-    is $param->coerce, undef, 'coerce';
-    ok !$param->positional, 'positional';
-    ok $param->named, 'named';
-    ok !$param->required, 'required';
-    ok $param->optional, 'optional';
-    ok !$param->invocant, 'not invocant';
-    ok $param->has_name;
-    ok $param->has_type;
-    ok $param->has_default;
-    ok !$param->has_coerce;
+subtest 'arg: name => $a' => sub {
+    my $param = Sub::Meta::Param->new({ name => '$a' });
+    test_submeta_param($param, {
+        name => '$a',
+    });
 };
 
-subtest 'setter' => sub {
-    my $param = Sub::Meta::Param->new;
-
-    is $param->set_name('$foo'), $param, 'set_name';
-    is $param->name, '$foo', 'name';
-
-    is $param->set_type('Type'), $param, 'set_type';
-    is $param->type, 'Type', 'type';
-    is $param->set_isa('Type2'), $param, 'set_isa';
-    is $param->isa_, 'Type2', 'type2';
-    is $param->type, 'Type2', 'type2';
-
-    is $param->set_default('Default'), $param, 'set_default';
-    is $param->default, 'Default', 'default';
-    is $param->set_coerce('Coerce'), $param, 'set_coerce';
-    is $param->coerce, 'Coerce', 'coerce';
-
-    is $param->set_optional, $param, 'set_optional';
-    ok $param->optional, 'optional';
-    is $param->set_optional(0), $param, 'set_optional';
-    ok !$param->optional, 'optional';
-
-    is $param->set_required, $param, 'set_required';
-    ok $param->required, 'required';
-    is $param->set_required(0), $param, 'set_required';
-    ok !$param->required, 'required';
-
-    is $param->set_positional, $param, 'set_positional';
-    ok $param->positional, 'positional';
-    is $param->set_positional(0), $param, 'set_positional';
-    ok !$param->positional, 'positional';
-
-    is $param->set_named, $param, 'set_named';
-    ok $param->named, 'named';
-    is $param->set_named(0), $param, 'set_named';
-    ok !$param->named, 'named';
-
-    is $param->set_invocant, $param, 'set_invocant';
-    ok $param->invocant, 'invocant';
-    is $param->set_invocant(0), $param, 'set_invocant';
-    ok !$param->invocant, 'invocant';
+subtest 'arg: default => hoge' => sub {
+    my $param = Sub::Meta::Param->new({ default => 'hoge' });
+    test_submeta_param($param, {
+        default => 'hoge',
+    });
 };
 
-subtest 'overload' => sub {
-    my $param = Sub::Meta::Param->new({ name => '$foo' });
-    ok $param eq $param;
+subtest 'arg: coerce => $sub' => sub {
+    my $sub = sub { };
+    my $param = Sub::Meta::Param->new({ coerce => $sub });
+    test_submeta_param($param, {
+        coerce => $sub,
+    });
 };
 
-subtest 'new' => sub {
-    is(Sub::Meta::Param->new(name => '$foo')->name, '$foo', 'args list');
+subtest 'arg: optional => !!1' => sub {
+    my $param = Sub::Meta::Param->new({ optional => !!1 });
+    test_submeta_param($param, {
+        optional => !!1,
+    });
+};
 
-    is(Sub::Meta::Param->new([])->type, [], 'args NOT HASH');
+subtest 'arg: named => !!1' => sub {
+    my $param = Sub::Meta::Param->new({ named => !!1 });
+    test_submeta_param($param, {
+        named => !!1,
+    });
+};
 
-    ok(Sub::Meta::Param->new(required => 0)->optional, 'args required');
-    ok(Sub::Meta::Param->new(positional => 0)->named, 'args positional');
+subtest 'arg: invocant => !!1' => sub {
+    my $param = Sub::Meta::Param->new({ invocant => !!1 });
+    test_submeta_param($param, {
+        invocant => !!1,
+    });
+};
 
-    ok(Sub::Meta::Param->new(invocant => 1)->invocant, 'args invocant');
-    ok(!Sub::Meta::Param->new(invocant => 0)->invocant, 'args invocant');
+subtest 'single arg is treated as a type' => sub {
+    test_submeta_param(Sub::Meta::Param->new('Str'), {
+        type => 'Str',
+    });
+
+    test_submeta_param(Sub::Meta::Param->new([]), {
+        type => [],
+    });
+
+    my $type = sub {};
+    test_submeta_param(Sub::Meta::Param->new($type), {
+        type => $type,
+    });
+
+    my $type2 = bless {}, 'Type';
+    test_submeta_param(Sub::Meta::Param->new($type2), {
+        type => $type2,
+    });
+};
+
+subtest 'mixed arg' => sub {
+    my $param = Sub::Meta::Param->new({
+        type     => 'Int',
+        name     => '$num',
+        default  => 999,
+        coerce   => undef,
+        optional => !!1,
+        named    => !!1,
+    });
+    test_submeta_param($param, {
+        type     => 'Int',
+        name     => '$num',
+        default  => 999,
+        coerce   => undef,
+        optional => !!1,
+        named    => !!1,
+    });
+};
+
+subtest 'other mixed arg' => sub {
+    my $default = sub {};
+    my $param = Sub::Meta::Param->new({
+        type     => 'Int',
+        name     => '$num',
+        default  => $default,
+    });
+    test_submeta_param($param, {
+        type     => 'Int',
+        name     => '$num',
+        default  => $default,
+        optional => !!0,
+        named    => !!0,
+    });
 };
 
 done_testing;

--- a/t/20-unit/Sub-Meta-Param/coerce.t
+++ b/t/20-unit/Sub-Meta-Param/coerce.t
@@ -1,0 +1,30 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+my $param = Sub::Meta::Param->new;
+
+subtest 'set coerce' => sub {
+    is $param->set_coerce('hoge'), $param;
+    test_submeta_param($param, { coerce => 'hoge' });
+};
+
+subtest 'set blessed' => sub {
+    my $coerce = bless {}, 'Default';
+    is $param->set_coerce($coerce), $param;
+    test_submeta_param($param, { coerce => $coerce });
+};
+
+subtest 'set coderef' => sub {
+    my $coerce = sub { 999 };
+    is $param->set_coerce($coerce), $param;
+    test_submeta_param($param, { coerce => $coerce });
+};
+
+subtest 'set undef' => sub {
+    is $param->set_coerce(undef), $param;
+    test_submeta_param($param, { coerce => undef });
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/default.t
+++ b/t/20-unit/Sub-Meta-Param/default.t
@@ -1,0 +1,30 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+my $param = Sub::Meta::Param->new;
+
+subtest 'set default' => sub {
+    is $param->set_default('hoge'), $param;
+    test_submeta_param($param, { default => 'hoge' });
+};
+
+subtest 'set blessed' => sub {
+    my $default = bless {}, 'Default';
+    is $param->set_default($default), $param;
+    test_submeta_param($param, { default => $default });
+};
+
+subtest 'set coderef' => sub {
+    my $default = sub { 999 };
+    is $param->set_default($default), $param;
+    test_submeta_param($param, { default => $default });
+};
+
+subtest 'set undef' => sub {
+    is $param->set_default(undef), $param;
+    test_submeta_param($param, { default => undef });
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/invocant.t
+++ b/t/20-unit/Sub-Meta-Param/invocant.t
@@ -1,0 +1,38 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+my $param = Sub::Meta::Param->new;
+
+subtest 'set invocant' => sub {
+    is $param->set_invocant('hoge'), $param;
+    test_submeta_param($param, { invocant => !!1 });
+};
+
+subtest 'set 1' => sub {
+    is $param->set_invocant(1), $param;
+    test_submeta_param($param, { invocant => !!1 });
+};
+
+subtest 'set 0' => sub {
+    is $param->set_invocant(0), $param;
+    test_submeta_param($param, { invocant => !!0 });
+};
+
+subtest 'set empty string' => sub {
+    is $param->set_invocant(''), $param;
+    test_submeta_param($param, { invocant => !!0 });
+};
+
+subtest 'set undef, then TRUE' => sub {
+    is $param->set_invocant(undef), $param;
+    test_submeta_param($param, { invocant => !!1 });
+};
+
+subtest 'set invocant / no args' => sub {
+    is $param->set_invocant, $param;
+    test_submeta_param($param, { invocant => !!1 });
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/name.t
+++ b/t/20-unit/Sub-Meta-Param/name.t
@@ -1,0 +1,23 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+my $param = Sub::Meta::Param->new;
+
+subtest 'set $foo' => sub {
+    is $param->set_name('$foo'), $param;
+    test_submeta_param($param, { name => '$foo' });
+};
+
+subtest 'set foo' => sub {
+    is $param->set_name('bar'), $param;
+    test_submeta_param($param, { name => 'bar' });
+};
+
+subtest 'set undef' => sub {
+    is $param->set_name(undef), $param;
+    test_submeta_param($param, { name => '' });
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/named.t
+++ b/t/20-unit/Sub-Meta-Param/named.t
@@ -1,0 +1,80 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+subtest 'set_named' => sub {
+    my $param = Sub::Meta::Param->new;
+
+    subtest 'set named' => sub {
+        is $param->set_named('hoge'), $param;
+        test_submeta_param($param, { named => !!1 });
+    };
+
+    subtest 'set 1' => sub {
+        is $param->set_named(1), $param;
+        test_submeta_param($param, { named => !!1 });
+    };
+
+    subtest 'set 0' => sub {
+        is $param->set_named(0), $param;
+        test_submeta_param($param, { named => !!0 });
+    };
+
+    subtest 'set empty string' => sub {
+        is $param->set_named(''), $param;
+        test_submeta_param($param, { named => !!0 });
+    };
+
+    subtest 'set undef, then TRUE' => sub {
+        is $param->set_named(undef), $param;
+        test_submeta_param($param, { named => !!1 });
+    };
+
+    subtest 'set named / no args' => sub {
+        is $param->set_named, $param;
+        test_submeta_param($param, { named => !!1 });
+    };
+};
+
+subtest 'set_positional' => sub {
+    my $param = Sub::Meta::Param->new;
+
+    subtest 'set positional' => sub {
+        is $param->set_positional('hoge'), $param;
+        is $param->positional, !!1;
+        test_submeta_param($param, { named => !!0 });
+    };
+
+    subtest 'set 1' => sub {
+        is $param->set_positional(1), $param;
+        is $param->positional, !!1;
+        test_submeta_param($param, { named => !!0 });
+    };
+
+    subtest 'set 0' => sub {
+        is $param->set_positional(0), $param;
+        is $param->positional, !!0;
+        test_submeta_param($param, { named => !!1 });
+    };
+
+    subtest 'set empty string' => sub {
+        is $param->set_positional(''), $param;
+        is $param->positional, !!0;
+        test_submeta_param($param, { named => !!1 });
+    };
+
+    subtest 'set undef, then TRUE' => sub {
+        is $param->set_positional(undef), $param;
+        is $param->positional, !!1;
+        test_submeta_param($param, { named => !!0 });
+    };
+
+    subtest 'set named / no args' => sub {
+        is $param->set_positional, $param;
+        is $param->positional, !!1;
+        test_submeta_param($param, { named => !!0 });
+    };
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/optional.t
+++ b/t/20-unit/Sub-Meta-Param/optional.t
@@ -1,0 +1,80 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+subtest 'set_optional' => sub {
+    my $param = Sub::Meta::Param->new;
+
+    subtest 'set optional' => sub {
+        is $param->set_optional('hoge'), $param;
+        test_submeta_param($param, { optional => !!1 });
+    };
+
+    subtest 'set 1' => sub {
+        is $param->set_optional(1), $param;
+        test_submeta_param($param, { optional => !!1 });
+    };
+
+    subtest 'set 0' => sub {
+        is $param->set_optional(0), $param;
+        test_submeta_param($param, { optional => !!0 });
+    };
+
+    subtest 'set empty string' => sub {
+        is $param->set_optional(''), $param;
+        test_submeta_param($param, { optional => !!0 });
+    };
+
+    subtest 'set undef, then TRUE' => sub {
+        is $param->set_optional(undef), $param;
+        test_submeta_param($param, { optional => !!1 });
+    };
+
+    subtest 'set optional / no args' => sub {
+        is $param->set_optional, $param;
+        test_submeta_param($param, { optional => !!1 });
+    };
+};
+
+subtest 'set_required' => sub {
+    my $param = Sub::Meta::Param->new;
+
+    subtest 'set required' => sub {
+        is $param->set_required('hoge'), $param;
+        is $param->required, !!1;
+        test_submeta_param($param, { optional => !!0 });
+    };
+
+    subtest 'set 1' => sub {
+        is $param->set_required(1), $param;
+        is $param->required, !!1;
+        test_submeta_param($param, { optional => !!0 });
+    };
+
+    subtest 'set 0' => sub {
+        is $param->set_required(0), $param;
+        is $param->required, !!0;
+        test_submeta_param($param, { optional => !!1 });
+    };
+
+    subtest 'set empty string' => sub {
+        is $param->set_required(''), $param;
+        is $param->required, !!0;
+        test_submeta_param($param, { optional => !!1 });
+    };
+
+    subtest 'set undef, then TRUE' => sub {
+        is $param->set_required(undef), $param;
+        is $param->required, !!1;
+        test_submeta_param($param, { optional => !!0 });
+    };
+
+    subtest 'set optional / no args' => sub {
+        is $param->set_required, $param;
+        is $param->required, !!1;
+        test_submeta_param($param, { optional => !!0 });
+    };
+};
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/overload.t
+++ b/t/20-unit/Sub-Meta-Param/overload.t
@@ -1,0 +1,13 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+
+my $param1 = Sub::Meta::Param->new({ name => '$foo' });
+my $param2 = Sub::Meta::Param->new({ name => '$bar' });
+my $param3 = Sub::Meta::Param->new({ name => '$foo' });
+
+ok $param1 eq $param1;
+ok $param1 ne $param2;
+ok $param1 eq $param3;
+
+done_testing;

--- a/t/20-unit/Sub-Meta-Param/type.t
+++ b/t/20-unit/Sub-Meta-Param/type.t
@@ -1,0 +1,30 @@
+use Test2::V0;
+
+use Sub::Meta::Param;
+use Sub::Meta::Test qw(test_submeta_param);
+
+my $param = Sub::Meta::Param->new;
+
+subtest 'set Str' => sub {
+    is $param->set_type('Str'), $param;
+    test_submeta_param($param, { type => 'Str' });
+};
+
+subtest 'set blessed' => sub {
+    my $Str = bless {}, 'Str';
+    is $param->set_type($Str), $param;
+    test_submeta_param($param, { type => $Str });
+};
+
+subtest 'set coderef' => sub {
+    my $Str = sub { };
+    is $param->set_type($Str), $param;
+    test_submeta_param($param, { type => $Str });
+};
+
+subtest 'set undef' => sub {
+    is $param->set_type(undef), $param;
+    test_submeta_param($param, { type => undef });
+};
+
+done_testing;


### PR DESCRIPTION
This pull request improves Sub::Meta::Param tests.

Incompatible change: do not return a empty string even if type is undef