### PR TITLE
feat: is_relaxed_same_interface and relaxed_error_message

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -3,6 +3,7 @@ severity = 3
 [-Subroutines::ProhibitExplicitReturnUndef]
 [-ValuesAndExpressions::ProhibitConstantPragma]
 [-RegularExpressions::RequireExtendedFormatting]
+[-ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions]
 
 [TestingAndDebugging::RequireUseStrict]
 equivalent_modules = Test2::V0

--- a/lib/Sub/Meta.pm
+++ b/lib/Sub/Meta.pm
@@ -397,15 +397,12 @@ sub interface_error_message {
         return sprintf('should not have subname. got: %s', $other->subname) if $other->has_subname;
     }
 
-    if ($self->is_method) {
-        return 'must be method' unless $other->is_method
-    }
-    else {
-        return 'should not be method' if $other->is_method;
+    if ($self->is_method ne $other->is_method) {
+        return 'invalid method';
     }
 
     if ($self->has_parameters) {
-        return $self->parameters->interface_error_message($other->parameters)
+        return "invalid parameters:" . $self->parameters->interface_error_message($other->parameters)
             unless $self->parameters->is_same_interface($other->parameters)
     }
     else {
@@ -413,7 +410,7 @@ sub interface_error_message {
     }
 
     if ($self->has_returns) {
-        return $self->returns->interface_error_message($other->returns)
+        return "invalid returns:" . $self->returns->interface_error_message($other->returns)
             unless $self->returns->is_same_interface($other->returns)
     }
     else {
@@ -433,17 +430,17 @@ sub child_error_message {
             unless $self->subname eq $child->subname
     }
 
-    if ($self->is_method) {
-        return 'must be method' unless $child->is_method
+    if ($self->is_method ne $child->is_method) {
+        return 'invalid method'
     }
 
     if ($self->has_parameters) {
-        return $self->parameters->child_error_message($child->parameters)
+        return "invalid parameters:" . $self->parameters->child_error_message($child->parameters)
             unless $self->parameters->is_child($child->parameters)
     }
 
     if ($self->has_returns) {
-        return $self->returns->child_error_message($child->returns)
+        return "invalid returns:" . $self->returns->child_error_message($child->returns)
             unless $self->returns->is_child($child->returns)
     }
     return '';

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -88,7 +88,7 @@ sub is_same_interface {
     return !!1;
 }
 
-sub is_child {
+sub is_relaxed_same_interface {
     my ($self, $child) = @_;
 
     return unless Scalar::Util::blessed($child) && $child->isa('Sub::Meta::Param');
@@ -127,7 +127,7 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
-sub is_child_inlined {
+sub is_relaxed_same_interface_inlined {
     my ($self, $v) = @_;
 
     my @src;

--- a/lib/Sub/Meta/Param.pm
+++ b/lib/Sub/Meta/Param.pm
@@ -88,6 +88,26 @@ sub is_same_interface {
     return !!1;
 }
 
+sub is_child {
+    my ($self, $child) = @_;
+
+    return unless Scalar::Util::blessed($child) && $child->isa('Sub::Meta::Param');
+
+    if ($self->has_name) {
+        return unless $self->name eq $child->name
+    }
+
+    if ($self->has_type) {
+        return unless $self->type eq ($child->type // '');
+    }
+
+    return unless $self->optional eq $child->optional;
+
+    return unless $self->named eq $child->named;
+
+    return !!1;
+}
+
 sub is_same_interface_inlined {
     my ($self, $v) = @_;
 
@@ -99,6 +119,23 @@ sub is_same_interface_inlined {
 
     push @src => $self->has_type ? sprintf("'%s' eq (%s->type // '')", "@{[$self->type]}", $v)
                                  : sprintf('!%s->has_type', $v);
+
+    push @src => sprintf("'%s' eq %s->optional", $self->optional, $v);
+
+    push @src => sprintf("'%s' eq %s->named", $self->named, $v);
+
+    return join "\n && ", @src;
+}
+
+sub is_child_inlined {
+    my ($self, $v) = @_;
+
+    my @src;
+    push @src => sprintf("Scalar::Util::blessed(%s) && %s->isa('Sub::Meta::Param')", $v, $v);
+
+    push @src => sprintf("'%s' eq %s->name", $self->name, $v) if $self->has_name;
+
+    push @src => sprintf("'%s' eq (%s->type // '')", "@{[$self->type]}", $v) if $self->has_type;
 
     push @src => sprintf("'%s' eq %s->optional", $self->optional, $v);
 

--- a/lib/Sub/Meta/Parameters.pm
+++ b/lib/Sub/Meta/Parameters.pm
@@ -264,7 +264,7 @@ sub interface_error_message {
     return sprintf('nshift is not equal. got: %d, expected: %d', $other->nshift, $self->nshift)
         unless $self->nshift == $other->nshift;
 
-    return sprintf('args length is not equal. got: %d, expected: %d', scalar @{$other->all_args}, scalar @{$self->all_args})
+    return sprintf('invalid args length. got: %d, expected: %d', scalar @{$other->all_args}, scalar @{$self->all_args})
         unless @{$self->all_args} == @{$other->all_args};
 
     for (my $i = 0; $i < @{$self->all_args}; $i++) {
@@ -291,7 +291,7 @@ sub child_error_message {
     return sprintf('nshift is not equal. got: %d, expected: %d', $child->nshift, $self->nshift)
         unless $self->nshift == $child->nshift;
 
-    return sprintf('parent args length is greator than child args. parent: %d, child: %d', scalar @{$child->all_args}, scalar @{$self->all_args})
+    return sprintf('invalid args length. got: %d, expected: %d', scalar @{$child->all_args}, scalar @{$self->all_args})
         unless @{$self->all_args} <= @{$child->all_args};
 
     for (my $i = 0; $i < @{$self->all_args}; $i++) {

--- a/lib/Sub/Meta/Parameters.pm
+++ b/lib/Sub/Meta/Parameters.pm
@@ -185,7 +185,7 @@ sub is_same_interface {
     return !!1;
 }
 
-sub is_child {
+sub is_relaxed_same_interface {
     my ($self, $child) = @_;
 
     return unless Scalar::Util::blessed($child) && $child->isa('Sub::Meta::Parameters');
@@ -199,7 +199,7 @@ sub is_child {
     return unless @{$self->all_args} <= @{$child->all_args};
 
     for (my $i = 0; $i < @{$self->all_args}; $i++) {
-        return unless $self->all_args->[$i]->is_child($child->all_args->[$i]);
+        return unless $self->all_args->[$i]->is_relaxed_same_interface($child->all_args->[$i]);
     }
 
     return !!1;
@@ -226,28 +226,28 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
-sub is_child_inlined {
+sub is_relaxed_same_interface_inlined {
     my ($self, $v) = @_;
 
     my @src;
 
     push @src => sprintf("Scalar::Util::blessed(%s) && %s->isa('Sub::Meta::Parameters')", $v, $v);
 
-    push @src => $self->slurpy->is_child_inlined(sprintf('%s->slurpy', $v)) if $self->has_slurpy; 
+    push @src => $self->slurpy->is_relaxed_same_interface_inlined(sprintf('%s->slurpy', $v)) if $self->has_slurpy; 
 
     push @src => sprintf('%d == %s->nshift', $self->nshift, $v);
 
     push @src => sprintf('%d <= @{%s->all_args}', scalar @{$self->all_args}, $v);
 
     for (my $i = 0; $i < @{$self->all_args}; $i++) {
-        push @src => $self->all_args->[$i]->is_child_inlined(sprintf('%s->all_args->[%d]', $v, $i))
+        push @src => $self->all_args->[$i]->is_relaxed_same_interface_inlined(sprintf('%s->all_args->[%d]', $v, $i))
     }
 
     return join "\n && ", @src;
 }
 
 
-sub interface_error_message {
+sub error_message {
     my ($self, $other) = @_;
 
     return sprintf('must be Sub::Meta::Parameters. got: %s', $other // '')
@@ -277,7 +277,7 @@ sub interface_error_message {
     return '';
 }
 
-sub child_error_message {
+sub relaxed_error_message {
     my ($self, $child) = @_;
 
     return sprintf('must be Sub::Meta::Parameters. got: %s', $child // '')
@@ -298,7 +298,7 @@ sub child_error_message {
         my $s = $self->all_args->[$i];
         my $o = $child->all_args->[$i];
         return sprintf('args[%d] is invalid. got: %s, expected: %s', $i, $o->display, $s->display)
-            unless $s->is_child($o);
+            unless $s->is_relaxed_same_interface($o);
     }
 
     return '';
@@ -561,9 +561,9 @@ Specifically, check whether C<args>, C<nshift> and C<slurpy> are equal.
 
 Returns inlined C<is_same_interface> string.
 
-=head3 interface_error_message($other_meta)
+=head3 error_message($other_meta)
 
-    method interface_error_message(InstanceOf[Sub::Meta::Parameters] $other_meta) => Str
+    method error_message(InstanceOf[Sub::Meta::Parameters] $other_meta) => Str
 
 Return the error message when the interface does not match.
 

--- a/lib/Sub/Meta/Returns.pm
+++ b/lib/Sub/Meta/Returns.pm
@@ -66,7 +66,7 @@ sub is_same_interface {
     return !!1;
 }
 
-sub is_child {
+sub is_relaxed_same_interface {
     my ($self, $child) = @_;
 
     return unless Scalar::Util::blessed($child) && $child->isa('Sub::Meta::Returns');
@@ -105,7 +105,7 @@ sub is_same_interface_inlined {
     return join "\n && ", @src;
 }
 
-sub is_child_inlined {
+sub is_relaxed_same_interface_inlined {
     my ($self, $v) = @_;
 
     my @src;
@@ -137,7 +137,7 @@ sub _eq {
     return 1;
 }
 
-sub interface_error_message {
+sub error_message {
     my ($self, $other) = @_;
 
     return sprintf('must be Sub::Meta::Returns. got: %s', $other // '')
@@ -169,7 +169,7 @@ sub interface_error_message {
     return '';
 }
 
-sub child_error_message {
+sub relaxed_error_message {
     my ($self, $child) = @_;
 
     return sprintf('must be Sub::Meta::Returns. got: %s', $child // '')
@@ -365,9 +365,9 @@ Specifically, check whether C<scalar>, C<list> and C<void> are equal.
 
 Returns inlined C<is_same_interface> string.
 
-=head3 interface_error_message($other_meta)
+=head3 error_message($other_meta)
 
-    method interface_error_message(InstanceOf[Sub::Meta::Returns] $other_meta) => Str
+    method error_message(InstanceOf[Sub::Meta::Returns] $other_meta) => Str
 
 Return the error message when the interface does not match. If match, then return empty string.
 

--- a/lib/Sub/Meta/Test.pm
+++ b/lib/Sub/Meta/Test.pm
@@ -7,7 +7,7 @@ our @EXPORT_OK = qw(
     sub_meta_parameters
     sub_meta_param
     test_is_same_interface
-    test_interface_error_message
+    test_error_message
     DummyType
 );
 
@@ -99,7 +99,7 @@ sub test_is_same_interface {
 
     ## no critic (ProhibitStringyEval)
     my $is_same_interface = eval sprintf('sub { %s }', $meta->is_same_interface_inlined('$_[0]'));
-    my $is_child = eval sprintf('sub { %s }', $meta->is_child_inlined('$_[0]'));
+    my $is_relaxed_same_interface = eval sprintf('sub { %s }', $meta->is_relaxed_same_interface_inlined('$_[0]'));
     ## use critic
 
     my $ctx = context;
@@ -113,27 +113,27 @@ sub test_is_same_interface {
         my $same = $meta->is_same_interface($other);
         my $same_inlined = $is_same_interface->($other);
 
-        my $child = $meta->is_child($other);
-        my $child_inlined = $is_child->($other);
+        my $child = $meta->is_relaxed_same_interface($other);
+        my $child_inlined = $is_relaxed_same_interface->($other);
 
         subtest "should $pass: $message" => sub {
             if ($pass eq 'pass') {
                 ok $same, 'is_same_interface';
                 ok $same_inlined, 'is_same_interface_inlined';
-                ok $child, 'is_child';
-                ok $child_inlined, 'is_child_inlined';
+                ok $child, 'is_relaxed_same_interface';
+                ok $child_inlined, 'is_relaxed_same_interface_inlined';
             }
             elsif ($pass eq 'pass_child') {
                 ok !$same, 'is_same_interface';
                 ok !$same_inlined, 'is_same_interface_inlined';
-                ok $child, 'is_child';
-                ok $child_inlined, 'is_child_inlined';
+                ok $child, 'is_relaxed_same_interface';
+                ok $child_inlined, 'is_relaxed_same_interface_inlined';
             }
             elsif($pass eq 'fail') {
                 ok !$same, 'is_same_interface';
                 ok !$same_inlined, 'is_same_interface_inlined';
-                ok !$child, 'is_child';
-                ok !$child_inlined, 'is_child_inlined';
+                ok !$child, 'is_relaxed_same_interface';
+                ok !$child_inlined, 'is_relaxed_same_interface_inlined';
             }
         };
     }
@@ -141,7 +141,7 @@ sub test_is_same_interface {
     return;
 }
 
-sub test_interface_error_message {
+sub test_error_message {
     my ($meta, @tests) = @_;
 
     my $ctx = context;
@@ -153,21 +153,21 @@ sub test_interface_error_message {
                   ? $meta_class->new($args)
                   : $args;
 
-        my $got   = $meta->interface_error_message($other);
-        my $child = $meta->child_error_message($other);
+        my $got   = $meta->error_message($other);
+        my $child = $meta->relaxed_error_message($other);
 
         subtest "should $pass: $expected" => sub {
             if ($pass eq 'pass') {
-                is $got, '', 'interface_error_message';
-                is $child, '', 'child_error_message';
+                is $got, '', 'error_message';
+                is $child, '', 'relaxed_error_message';
             }
             elsif ($pass eq 'pass_child') {
-                like $got, $expected, 'interface_error_message';
-                is $child, '', 'child_error_message';
+                like $got, $expected, 'error_message';
+                is $child, '', 'relaxed_error_message';
             }
             elsif ($pass eq 'fail') {
-                like $got, $expected, 'interface_error_message';
-                like $child, $expected, 'child_error_message';
+                like $got, $expected, 'error_message';
+                like $child, $expected, 'relaxed_error_message';
             }
         };
     }
@@ -243,9 +243,9 @@ Testing utility for Sub::Meta::Param object.
 Testing utility for is_same_interface method of Sub::Meta,
 Sub::Meta::Param, Sub::Meta::Parameters and Sub::Meta::Returns.
 
-=head3 test_interface_error_message
+=head3 test_error_message
 
-Testing utility for interface_error_message method of Sub::Meta,
+Testing utility for error_message method of Sub::Meta,
 Sub::Meta::Parameters and Sub::Meta::Returns.
 
 =head3 DummyType

--- a/lib/Sub/Meta/Test.pm
+++ b/lib/Sub/Meta/Test.pm
@@ -148,19 +148,28 @@ sub test_interface_error_message {
     my $meta_class = ref $meta;
 
     while (@tests) {
-        my ($args, $expected) = splice @tests, 0, 2;
+        my ($pass, $args, $expected) = splice @tests, 0, 3;
         my $other = ref $args && ref $args eq 'HASH'
                   ? $meta_class->new($args)
                   : $args;
 
-        my $result = $meta->interface_error_message($other);
+        my $got   = $meta->interface_error_message($other);
+        my $child = $meta->child_error_message($other);
 
-        if (ref $expected && ref $expected eq 'Regexp') {
-            like $result, $expected;
-        }
-        else {
-            is $result, $expected;
-        }
+        subtest "should $pass: $expected" => sub {
+            if ($pass eq 'pass') {
+                is $got, '', 'interface_error_message';
+                is $child, '', 'child_error_message';
+            }
+            elsif ($pass eq 'pass_child') {
+                like $got, $expected, 'interface_error_message';
+                is $child, '', 'child_error_message';
+            }
+            elsif ($pass eq 'fail') {
+                like $got, $expected, 'interface_error_message';
+                like $child, $expected, 'child_error_message';
+            }
+        };
     }
 
     $ctx->release;

--- a/lib/Sub/Meta/Test.pm
+++ b/lib/Sub/Meta/Test.pm
@@ -97,8 +97,10 @@ sub sub_meta_param {
 sub test_is_same_interface {
     my ($meta, @tests) = @_;
 
-    my $inline = $meta->is_same_interface_inlined('$_[0]');
-    my $is_same_interface = eval sprintf('sub { %s }', $inline); ## no critic (ProhibitStringyEval)
+    ## no critic (ProhibitStringyEval)
+    my $is_same_interface = eval sprintf('sub { %s }', $meta->is_same_interface_inlined('$_[0]'));
+    my $is_child = eval sprintf('sub { %s }', $meta->is_child_inlined('$_[0]'));
+    ## use critic
 
     my $ctx = context;
     my $meta_class = ref $meta;
@@ -108,17 +110,30 @@ sub test_is_same_interface {
                   ? $meta_class->new($args)
                   : $args;
 
-        my $result = $meta->is_same_interface($other);
-        my $result_inlined = $is_same_interface->($other);
+        my $same = $meta->is_same_interface($other);
+        my $same_inlined = $is_same_interface->($other);
+
+        my $child = $meta->is_child($other);
+        my $child_inlined = $is_child->($other);
 
         subtest "should $pass: $message" => sub {
             if ($pass eq 'pass') {
-                ok $result, 'is_same_interface';
-                ok $result_inlined, 'is_same_interface_inlined';
+                ok $same, 'is_same_interface';
+                ok $same_inlined, 'is_same_interface_inlined';
+                ok $child, 'is_child';
+                ok $child_inlined, 'is_child_inlined';
+            }
+            elsif ($pass eq 'pass_child') {
+                ok !$same, 'is_same_interface';
+                ok !$same_inlined, 'is_same_interface_inlined';
+                ok $child, 'is_child';
+                ok $child_inlined, 'is_child_inlined';
             }
             elsif($pass eq 'fail') {
-                ok !$result, 'is_same_interface';
-                ok !$result_inlined, 'is_same_interface_inlined';
+                ok !$same, 'is_same_interface';
+                ok !$same_inlined, 'is_same_interface_inlined';
+                ok !$child, 'is_child';
+                ok !$child_inlined, 'is_child_inlined';
             }
         };
     }

--- a/t/20-unit/Sub-Meta-Param/is_same_interface.t
+++ b/t/20-unit/Sub-Meta-Param/is_same_interface.t
@@ -21,11 +21,11 @@ subtest "full args : { name => '\$msg', type => 'Str', required => 1, positional
 subtest "no name: { type => 'Str', required => 1, positional => 1 }" => sub {
     my $meta = Sub::Meta::Param->new({ type => 'Str', required => 1, positional => 1 });
     my @tests = (
-        fail => 'invalid type'       => { type => 'Srt', required => 1, positional => 1 },
-        fail => 'invalid required'   => { type => 'Str', required => 0, positional => 1 },
-        fail => 'invalid positional' => { type => 'Str', required => 1, positional => 0 },
-        fail => 'not need name'      => { type => 'Str', required => 1, positional => 1, name => '$foo' },
-        pass => 'valid'              => { type => 'Str', required => 1, positional => 1 },
+        fail       => 'invalid type'       => { type => 'Srt', required => 1, positional => 1 },
+        fail       => 'invalid required'   => { type => 'Str', required => 0, positional => 1 },
+        fail       => 'invalid positional' => { type => 'Str', required => 1, positional => 0 },
+        pass_child => 'not need name'      => { type => 'Str', required => 1, positional => 1, name => '$foo' },
+        pass       => 'valid'              => { type => 'Str', required => 1, positional => 1 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -33,11 +33,11 @@ subtest "no name: { type => 'Str', required => 1, positional => 1 }" => sub {
 subtest "no type: { name => '\$foo', required => 1, positional => 1 }" => sub {
     my $meta = Sub::Meta::Param->new({ name => '$foo', required => 1, positional => 1 });
     my @tests = (
-        fail => 'invalid name'       => { name => '$boo', required => 1, positional => 1 },
-        fail => 'invalid required'   => { name => '$foo', required => 0, positional => 1 },
-        fail => 'invalid positional' => { name => '$foo', required => 1, positional => 0 },
-        fail => 'not need type'      => { name => '$foo', required => 1, positional => 1, type => 'Str' },
-        pass => 'valid'              => { name => '$foo', required => 1, positional => 1 },
+        fail       => 'invalid name'       => { name => '$boo', required => 1, positional => 1 },
+        fail       => 'invalid required'   => { name => '$foo', required => 0, positional => 1 },
+        fail       => 'invalid positional' => { name => '$foo', required => 1, positional => 0 },
+        pass_child => 'not need type'      => { name => '$foo', required => 1, positional => 1, type => 'Str' },
+        pass       => 'valid'              => { name => '$foo', required => 1, positional => 1 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -45,11 +45,11 @@ subtest "no type: { name => '\$foo', required => 1, positional => 1 }" => sub {
 subtest "no name and type: { required => 1, positional => 1 }" => sub {
     my $meta = Sub::Meta::Param->new({ required => 1, positional => 1 });
     my @tests = (
-        fail => 'invalid required'   => { required => 0, positional => 1 },
-        fail => 'invalid positional' => { required => 1, positional => 0 },
-        fail => 'not need name'      => { required => 1, positional => 1, name => '$foo' },
-        fail => 'not need type'      => { required => 1, positional => 1, type => 'Str' },
-        pass => 'valid'              => { required => 1, positional => 1 },
+        fail       => 'invalid required'    => { required => 0, positional => 1 },
+        fail       => 'invalid positional'  => { required => 1, positional => 0 },
+        pass_child => 'not need name'       => { required => 1, positional => 1, name => '$foo' },
+        pass_child => 'not need type'       => { required => 1, positional => 1, type => 'Str' },
+        pass       => 'valid'               => { required => 1, positional => 1 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -57,10 +57,11 @@ subtest "no name and type: { required => 1, positional => 1 }" => sub {
 subtest "undef optional: { optional => undef }" => sub {
     my $meta = Sub::Meta::Param->new({ optional => undef });
     my @tests = (
-        fail => 'invalid optional' => { optional => 1 },
-        pass => 'valid'            => { optional => undef },
-        pass => 'valid'            => { optional => 0 },
-        pass => 'valid'            => { required => !!1 },
+        fail       => 'invalid optional' => { optional => 1 },
+        pass_child => 'not need name'    => { optional => undef, name => '$opts' },
+        pass       => 'valid'            => { optional => undef },
+        pass       => 'valid'            => { optional => 0 },
+        pass       => 'valid'            => { required => !!1 },
     );
     test_is_same_interface($meta, @tests);
 };

--- a/t/20-unit/Sub-Meta-Parameters/error_message.t
+++ b/t/20-unit/Sub-Meta-Parameters/error_message.t
@@ -1,7 +1,7 @@
 use Test2::V0;
 
 use Sub::Meta::Parameters;
-use Sub::Meta::Test qw(test_interface_error_message);
+use Sub::Meta::Test qw(test_error_message);
 
 my $Slurpy = Sub::Meta::Param->new("Slurpy");
 my $Str = Sub::Meta::Param->new("Str");
@@ -20,7 +20,7 @@ subtest "{ args => [] }" => sub {
         pass        => { args => [], nshift => 0 },                  qr//, # valid
         pass        => { args => [], slurpy => undef, nshift => 0 }, qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
  
 subtest "one args: { args => [\$Str] }" => sub {
@@ -30,7 +30,7 @@ subtest "one args: { args => [\$Str] }" => sub {
         fail => { args => [$Int] }, qr/^args\[0\] is invalid. got: Int, expected: Str/,
         pass => { args => [$Str] }, qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
  
 subtest "two args: { args => [\$Str, \$Int] }" => sub {
@@ -40,7 +40,7 @@ subtest "two args: { args => [\$Str, \$Int] }" => sub {
         fail => { args => [$Str, $Str] }, qr/^args\[1\] is invalid. got: Str, expected: Int/,
         pass => { args => [$Str, $Int] }, qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
  
 subtest "slurpy: { args => [], slurpy => \$Str }" => sub {
@@ -50,7 +50,7 @@ subtest "slurpy: { args => [], slurpy => \$Str }" => sub {
         fail => { args => [], slurpy => $Int }, qr/^invalid slurpy. got: Int, expected: Str/,
         pass => { args => [], slurpy => $Str }, qr//, # 'valid',
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
  
 subtest "nshift: { args => [], nshift => 1 }" => sub {
@@ -60,7 +60,7 @@ subtest "nshift: { args => [], nshift => 1 }" => sub {
         fail => { args => [], nshift => 0},  qr/^nshift is not equal. got: 0, expected: 1/,
         pass => { args => [], nshift => 1 }, qr//, # 'valid',
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
  
 done_testing;

--- a/t/20-unit/Sub-Meta-Parameters/interface_error_message.t
+++ b/t/20-unit/Sub-Meta-Parameters/interface_error_message.t
@@ -10,15 +10,15 @@ my $Int = Sub::Meta::Param->new("Int");
 subtest "{ args => [] }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [] });
     my @tests = (
-        undef, 'must be Sub::Meta::Parameters. got: ',
-        (bless {} => 'Some'), qr/^must be Sub::Meta::Parameters\. got: Some/,
-        { args => [$Str] }, 'args length is not equal. got: 1, expected: 0', 
-        { args => [], slurpy => $Slurpy }, 'should not have slurpy', 
-        { args => [], nshift => 1 }, 'nshift is not equal. got: 1, expected: 0', 
-        { args => [] }, '', # valid
-        { args => [], slurpy => undef }, '', # valid
-        { args => [], nshift => 0 }, '', # valid
-        { args => [], slurpy => undef, nshift => 0 }, '', # valid
+        fail        => undef,                                        qr/^must be Sub::Meta::Parameters. got: /,
+        fail        => (bless {} => 'Some'),                         qr/^must be Sub::Meta::Parameters\. got: Some/,
+        pass_child  => { args => [$Str] },                           qr/^invalid args length. got: 1, expected: 0/, 
+        pass_child  => { args => [], slurpy => $Slurpy },            qr/^should not have slurpy/, 
+        fail        => { args => [], nshift => 1 },                  qr/^nshift is not equal. got: 1, expected: 0/, 
+        pass        => { args => [] },                               qr//, # valid
+        pass        => { args => [], slurpy => undef },              qr//, # valid
+        pass        => { args => [], nshift => 0 },                  qr//, # valid
+        pass        => { args => [], slurpy => undef, nshift => 0 }, qr//, # valid
     );
     test_interface_error_message($meta, @tests);
 };
@@ -26,8 +26,9 @@ subtest "{ args => [] }" => sub {
 subtest "one args: { args => [\$Str] }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [$Str] });
     my @tests = (
-        { args => [$Int] }, 'args[0] is invalid. got: Int, expected: Str',
-        { args => [$Str] }, '', # valid
+        fail => { args => [] },     qr/^invalid args length. got: 0, expected: 1/,
+        fail => { args => [$Int] }, qr/^args\[0\] is invalid. got: Int, expected: Str/,
+        pass => { args => [$Str] }, qr//, # valid
     );
     test_interface_error_message($meta, @tests);
 };
@@ -35,9 +36,9 @@ subtest "one args: { args => [\$Str] }" => sub {
 subtest "two args: { args => [\$Str, \$Int] }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [$Str, $Int] });
     my @tests = (
-        { args => [$Int, $Str] }, 'args[0] is invalid. got: Int, expected: Str',
-        { args => [$Str, $Str] }, 'args[1] is invalid. got: Str, expected: Int',
-        { args => [$Str, $Int] }, '', # valid
+        fail => { args => [$Int, $Str] }, qr/^args\[0\] is invalid. got: Int, expected: Str/,
+        fail => { args => [$Str, $Str] }, qr/^args\[1\] is invalid. got: Str, expected: Int/,
+        pass => { args => [$Str, $Int] }, qr//, # valid
     );
     test_interface_error_message($meta, @tests);
 };
@@ -45,9 +46,9 @@ subtest "two args: { args => [\$Str, \$Int] }" => sub {
 subtest "slurpy: { args => [], slurpy => \$Str }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], slurpy => $Str });
     my @tests = (
-        { args => [] }, 'invalid slurpy. got: , expected: Str',
-        { args => [], slurpy => $Int }, 'invalid slurpy. got: Int, expected: Str',
-        { args => [], slurpy => $Str }, '', # 'valid',
+        fail => { args => [] },                 qr/^invalid slurpy. got: , expected: Str/,
+        fail => { args => [], slurpy => $Int }, qr/^invalid slurpy. got: Int, expected: Str/,
+        pass => { args => [], slurpy => $Str }, qr//, # 'valid',
     );
     test_interface_error_message($meta, @tests);
 };
@@ -55,9 +56,9 @@ subtest "slurpy: { args => [], slurpy => \$Str }" => sub {
 subtest "nshift: { args => [], nshift => 1 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], nshift => 1 });
     my @tests = (
-        { args => [] }, 'nshift is not equal. got: 0, expected: 1',
-        { args => [], nshift => 0}, 'nshift is not equal. got: 0, expected: 1',
-        { args => [], nshift => 1 }, '', # 'valid',
+        fail => { args => [] },              qr/^nshift is not equal. got: 0, expected: 1/,
+        fail => { args => [], nshift => 0},  qr/^nshift is not equal. got: 0, expected: 1/,
+        pass => { args => [], nshift => 1 }, qr//, # 'valid',
     );
     test_interface_error_message($meta, @tests);
 };

--- a/t/20-unit/Sub-Meta-Parameters/is_same_interface.t
+++ b/t/20-unit/Sub-Meta-Parameters/is_same_interface.t
@@ -13,12 +13,12 @@ my $slurpy         = Sub::Meta::Param->new("Slurpy");
 subtest "{ args => [], slurpy => undef, nshift => 0 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], slurpy => undef, nshift => 0 });
     my @tests = (
-        fail => 'invalid other'  => undef,
-        fail => 'invalid obj'    => (bless {} => 'Some'),
-        fail => 'invalid args'   => { args => [$p1], slurpy => undef, nshift => 0 },
-        fail => 'invalid slurpy' => { args => [], slurpy => $slurpy, nshift => 0 },
-        fail => 'invalid nshift' => { args => [], slurpy => undef, nshift => 1 },
-        pass => 'valid'          => { args => [], slurpy => undef, nshift => 0 },
+        fail       => 'invalid other'   => undef,
+        fail       => 'invalid obj'     => (bless {} => 'Some'),
+        pass_child => 'invalid args'    => { args => [$p1], slurpy => undef, nshift => 0 },
+        pass_child => 'not need slurpy' => { args => [], slurpy => $slurpy, nshift => 0 },
+        fail       => 'invalid nshift'  => { args => [], slurpy => undef, nshift => 1 },
+        pass       => 'valid'           => { args => [], slurpy => undef, nshift => 0 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -26,10 +26,10 @@ subtest "{ args => [], slurpy => undef, nshift => 0 }" => sub {
 subtest "one args: { args => [\$p1], slurpy => undef, nshift => 0 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [$p1], slurpy => undef, nshift => 0 });
     my @tests = (
-        fail => 'invalid args'  => { args => [$p2], slurpy => undef, nshift => 0 },
-        fail => 'too many args' => { args => [$p1, $p2], slurpy => undef, nshift => 0 },
-        fail => 'too few args'  => { args => [], slurpy => undef, nshift => 0 },
-        pass => 'valid'         => { args => [$p1], slurpy => undef, nshift => 0 },
+        fail       => 'invalid args'  => { args => [$p2], slurpy => undef, nshift => 0 },
+        pass_child => 'too many args' => { args => [$p1, $p2], slurpy => undef, nshift => 0 },
+        fail       => 'too few args'  => { args => [], slurpy => undef, nshift => 0 },
+        pass       => 'valid'         => { args => [$p1], slurpy => undef, nshift => 0 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -37,10 +37,10 @@ subtest "one args: { args => [\$p1], slurpy => undef, nshift => 0 }" => sub {
 subtest "two args: { args => [$p1, $p2], slurpy => undef, nshift => 0 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [$p1, $p2], slurpy => undef, nshift => 0 });
     my @tests = (
-        fail => 'invalid args'  => { args => [$p2, $p1], slurpy => undef, nshift => 0 },
-        fail => 'too many args' => { args => [$p1, $p2, $p1], slurpy => undef, nshift => 0 },
-        fail => 'too few args'  => { args => [$p1], slurpy => undef, nshift => 0 },
-        pass => 'valid'         => { args => [$p1, $p2], slurpy => undef, nshift => 0 },
+        fail       => 'invalid args'  => { args => [$p2, $p1], slurpy => undef, nshift => 0 },
+        pass_child => 'too many args' => { args => [$p1, $p2, $p1], slurpy => undef, nshift => 0 },
+        fail       => 'too few args'  => { args => [$p1], slurpy => undef, nshift => 0 },
+        pass       => 'valid'         => { args => [$p1, $p2], slurpy => undef, nshift => 0 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -59,8 +59,10 @@ subtest "slurpy: { args => [], slurpy => $slurpy, nshift => 0 }" => sub {
 subtest "empty slurpy: { args => [], nshift => 0 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], nshift => 0 });
     my @tests = (
-        fail => 'invalid slurpy' => { args => [], slurpy => 'Str', nshift => 0 },
-        pass => 'valid'          => { args => [], nshift => 0 },
+        fail       => 'invalid'         => { args => [], nshift => 1 },
+        pass_child => 'not need args'   => { args => [$p1], nshift => 0 },
+        pass_child => 'not need slurpy' => { args => [], slurpy => 'Str', nshift => 0 },
+        pass       => 'valid'           => { args => [], nshift => 0 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -68,10 +70,10 @@ subtest "empty slurpy: { args => [], nshift => 0 }" => sub {
 subtest "nshift: { args => [\$p1], slurpy => undef, nshift => 1 }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [$p1], slurpy => undef, nshift => 1 });
     my @tests = (
-        fail => 'invalid args'   => { args => [$p2], slurpy => undef, nshift => 1 },
-        fail => 'too many args'  => { args => [$p1, $p2], slurpy => undef, nshift => 1 },
-        fail => 'invalid slurpy' => { args => [$p1], slurpy => $slurpy, nshift => 1 },
-        pass => 'valid'          => { args => [$p1], slurpy => undef, nshift => 1 },
+        fail       => 'invalid args'    => { args => [$p2], slurpy => undef, nshift => 1 },
+        pass_child => 'not need slurpy' => { args => [$p1], slurpy => $slurpy, nshift => 1 },
+        pass_child => 'too many args'   => { args => [$p1, $p2], slurpy => undef, nshift => 1 },
+        pass       => 'valid'           => { args => [$p1], slurpy => undef, nshift => 1 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -80,28 +82,28 @@ subtest "slurpy & nshift: { args => [\$p1], slurpy => \$slurpy, nshift => 1 }" =
 
     my $meta = Sub::Meta::Parameters->new({ args => [$p1], slurpy => $slurpy, nshift => 1 });
     my @tests = (
-        fail => 'invalid args'   => { args => [$p2], slurpy => $slurpy, nshift => 1 },
-        fail => 'too many args'  => { args => [$p1, $p2], slurpy => $slurpy, nshift => 1 },
-        fail => 'invalid slurpy' => { args => [$p1], slurpy => undef, nshift => 1 },
-        fail => 'invalid nshift' => { args => [$p1], slurpy => $slurpy, nshift => 0 },
-        fail => 'valid'          => { args => [$p1], slurpy => $slurpy, invocant => $invocant_self },
-        pass => 'valid'          => { args => [$p1], slurpy => $slurpy, nshift => 1 },
-        pass => 'valid'          => { args => [$p1], slurpy => $slurpy, invocant => $invocant },
+        fail       => 'invalid args'          => { args => [$p2], slurpy => $slurpy, nshift => 1 },
+        fail       => 'invalid slurpy'        => { args => [$p1], slurpy => undef, nshift => 1 },
+        fail       => 'invalid nshift'        => { args => [$p1], slurpy => $slurpy, nshift => 0 },
+        pass_child => 'too many args'         => { args => [$p1, $p2], slurpy => $slurpy, nshift => 1 },
+        pass_child => 'invalid invocant name' => { args => [$p1], slurpy => $slurpy, invocant => $invocant_self },
+        pass       => 'valid'                 => { args => [$p1], slurpy => $slurpy, nshift => 1 },
+        pass       => 'valid'                 => { args => [$p1], slurpy => $slurpy, invocant => $invocant },
     );
     test_is_same_interface($meta, @tests);
 };
 
-subtest "default invocant: { args => [], invocant => $invocant }" => sub {
+subtest "default invocant: { args => [], invocant => \$invocant }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], invocant => $invocant });
     my @tests = (
-        fail => 'invalid invocant' => { args => [], invocant => $invocant_class },
-        pass => 'valid'            => { args => [], invocant => $invocant },
-        pass => 'valid nshift'     => { args => [], nshift => 1 },
+        pass_child => 'invalid invocant name' => { args => [], invocant => $invocant_class },
+        pass       => 'valid'                 => { args => [], invocant => $invocant },
+        pass       => 'valid nshift'          => { args => [], nshift => 1 },
     );
     test_is_same_interface($meta, @tests);
 };
 
-subtest "invocant: { args => [], invocant => param(invocant => 1, name => '\$self') }" => sub {
+subtest "invocant: { args => [], invocant => \$invocant_self }" => sub {
     my $meta = Sub::Meta::Parameters->new({ args => [], invocant => $invocant_self });
     my @tests = (
         fail => 'invalid nshift'    => { args => [], nshift => 0 },

--- a/t/20-unit/Sub-Meta-Returns/error_message.t
+++ b/t/20-unit/Sub-Meta-Returns/error_message.t
@@ -1,7 +1,7 @@
 use Test2::V0;
 
 use Sub::Meta::Returns;
-use Sub::Meta::Test qw(test_interface_error_message);
+use Sub::Meta::Test qw(test_error_message);
 
 subtest "{ scalar => 'Str' }" => sub {
     my $meta = Sub::Meta::Returns->new({ scalar => 'Str' });
@@ -14,7 +14,7 @@ subtest "{ scalar => 'Str' }" => sub {
         pass       => { scalar => 'Str' },                               qr//,
         pass       => { scalar => 'Str', list => undef, void => undef }, qr//,
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "{ list => 'Str' }" => sub {
@@ -26,7 +26,7 @@ subtest "{ list => 'Str' }" => sub {
         pass       => { list => 'Str' },                                 qr//,
         pass       => { list => 'Str', scalar => undef, void => undef }, qr//,
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "{ void => 'Str' }" => sub {
@@ -38,7 +38,7 @@ subtest "{ void => 'Str' }" => sub {
         pass       => { void => 'Str' },                                 qr//,
         pass       => { void => 'Str', list => undef, scalar => undef }, qr//,
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 done_testing;

--- a/t/20-unit/Sub-Meta-Returns/interface_error_message.t
+++ b/t/20-unit/Sub-Meta-Returns/interface_error_message.t
@@ -6,13 +6,13 @@ use Sub::Meta::Test qw(test_interface_error_message);
 subtest "{ scalar => 'Str' }" => sub {
     my $meta = Sub::Meta::Returns->new({ scalar => 'Str' });
     my @tests = (
-        undef, 'must be Sub::Meta::Returns. got: ',
-        (bless {} => 'Some'), qr/^must be Sub::Meta::Returns\. got: Some/,
-        { scalar => 'Int' }, 'invalid scalar return. got: Int, expected: Str',
-        { scalar => 'Str', list => 'Str' }, 'should not have list return',
-        { scalar => 'Str', void => 'Str' }, 'should not have void return',
-        { scalar => 'Str' }, '', # valid
-        { scalar => 'Str', list => undef, void => undef }, '', # valid
+        fail       => undef,                                             qr/^must be Sub::Meta::Returns. got: /,
+        fail       => (bless {} => 'Some'),                              qr/^must be Sub::Meta::Returns. got: Some/,
+        fail       => { scalar => 'Int' },                               qr/^invalid scalar return. got: Int, expected: Str/,
+        pass_child => { scalar => 'Str', list => 'Str' },                qr/^should not have list return/,
+        pass_child => { scalar => 'Str', void => 'Str' },                qr/^should not have void return/,
+        pass       => { scalar => 'Str' },                               qr//,
+        pass       => { scalar => 'Str', list => undef, void => undef }, qr//,
     );
     test_interface_error_message($meta, @tests);
 };
@@ -20,11 +20,11 @@ subtest "{ scalar => 'Str' }" => sub {
 subtest "{ list => 'Str' }" => sub {
     my $meta = Sub::Meta::Returns->new({ list => 'Str' });
     my @tests = (
-        { list => 'Int' }, 'invalid list return. got: Int, expected: Str',
-        { list => 'Str', scalar => 'Str' }, 'should not have scalar return',
-        { list => 'Str', void => 'Str' }, 'should not have void return',
-        { list => 'Str' }, '', # valid
-        { list => 'Str', scalar => undef, void => undef }, '', # valid
+        fail       => { list => 'Int' },                                 qr/^invalid list return. got: Int, expected: Str/,
+        pass_child => { list => 'Str', scalar => 'Str' },                qr/^should not have scalar return/,
+        pass_child => { list => 'Str', void => 'Str' },                  qr/^should not have void return/,
+        pass       => { list => 'Str' },                                 qr//,
+        pass       => { list => 'Str', scalar => undef, void => undef }, qr//,
     );
     test_interface_error_message($meta, @tests);
 };
@@ -32,11 +32,11 @@ subtest "{ list => 'Str' }" => sub {
 subtest "{ void => 'Str' }" => sub {
     my $meta = Sub::Meta::Returns->new({ void => 'Str' });
     my @tests = (
-        { void => 'Int' }, 'invalid void return. got: Int, expected: Str',
-        { void => 'Str', scalar => 'Str' }, 'should not have scalar return',
-        { void => 'Str', list => 'Str' }, 'should not have list return',
-        { void => 'Str' }, '', # valid
-        { void => 'Str', scalar => undef, list => undef }, '', # valid
+        fail       => { void => 'Int' },                                 qr/^invalid void return. got: Int, expected: Str/,
+        pass_child => { void => 'Str', scalar => 'Str' },                qr/^should not have scalar return/,
+        pass_child => { void => 'Str', list => 'Str' },                  qr/^should not have list return/,
+        pass       => { void => 'Str' },                                 qr//,
+        pass       => { void => 'Str', list => undef, scalar => undef }, qr//,
     );
     test_interface_error_message($meta, @tests);
 };

--- a/t/20-unit/Sub-Meta-Returns/is_same_interface.t
+++ b/t/20-unit/Sub-Meta-Returns/is_same_interface.t
@@ -9,8 +9,8 @@ subtest "scalar: { scalar => 'Str', list => undef, void => undef }" => sub {
         fail => 'invalid other'  => undef,
         fail => 'invalid obj'    => (bless {} => 'Some'),
         fail => 'invalid scalar' => { scalar => 'Int', list => undef, void => undef },
-        fail => 'invalid list'   => { scalar => 'Str', list => 'Str', void => undef },
-        fail => 'invalid void'   => { scalar => 'Str', list => undef, void => 'Str' },
+        pass_child => 'invalid list'   => { scalar => 'Str', list => 'Str', void => undef },
+        pass_child => 'invalid void'   => { scalar => 'Str', list => undef, void => 'Str' },
         pass => 'valid'          => { scalar => 'Str', list => undef, void => undef },
     );
     test_is_same_interface($meta, @tests);
@@ -20,8 +20,8 @@ subtest "list: { scalar => undef, list => 'Str', void => undef }" => sub {
     my $meta = Sub::Meta::Returns->new({ scalar => undef, list => 'Str', void => undef });
     my @tests = (
         fail => 'invalid list'   => { scalar => undef, list => 'Int', void => undef },
-        fail => 'invalid scalar' => { scalar => 'Str', list => 'Str', void => undef },
-        fail => 'invalid void'   => { scalar => undef, list => 'Str', void => 'Str' },
+        pass_child => 'invalid scalar' => { scalar => 'Str', list => 'Str', void => undef },
+        pass_child => 'invalid void'   => { scalar => undef, list => 'Str', void => 'Str' },
         pass => 'valid'          => { scalar => undef, list => 'Str', void => undef },
     );
     test_is_same_interface($meta, @tests);
@@ -31,8 +31,8 @@ subtest "void: { scalar => undef, list => undef, void => 'Str' }" => sub {
     my $meta = Sub::Meta::Returns->new({ scalar => undef, list => undef, void => 'Str' });
     my @tests = (
         fail => 'invalid void'   => { scalar => undef, list => undef, void => 'Int' },
-        fail => 'invalid scalar' => { scalar => 'Str', list => undef, void => 'Str' },
-        fail => 'invalid list'   => { scalar => undef, list => 'Str', void => 'Str' },
+        pass_child => 'invalid scalar' => { scalar => 'Str', list => undef, void => 'Str' },
+        pass_child => 'invalid list'   => { scalar => undef, list => 'Str', void => 'Str' },
         pass => 'valid'          => { scalar => undef, list => undef, void => 'Str' },
     );
     test_is_same_interface($meta, @tests);

--- a/t/20-unit/Sub-Meta-Test/test_interface_error_message.t
+++ b/t/20-unit/Sub-Meta-Test/test_interface_error_message.t
@@ -7,28 +7,20 @@ subtest 'Fail: test_interface_error_message' => sub {
     my $events = intercept {
         my $meta = Sub::Meta->new();
         my @tests = (
-            { }, '',
-            { }, qr//,
-            { }, sub {},
+            hoge => { }, qr//,
         );
         test_interface_error_message($meta, @tests);
     };
 
     is $events, array {
-        event 'Ok';
-        event 'Ok';
-        event 'Fail';
+        event 'Subtest';
+        event 'Diag';
         end;
     };
 
-    my (undef, undef, $fail) = @$events;
-    my $table = $fail->info->[0]{table};
-    is $table->{header}, [
-        "PATH", "LNs", "GOT", "OP", "CHECK", "LNs"
-    ];
-    is $table->{rows}, [
-        [ '', D(), '', '==', D(), D() ],
-    ];
+    my ($subtest) = @$events;
+    my $summary = $subtest->subevents->[0]->summary;
+    like $summary, qr/Plan is 0 assertions/;
 };
 
 done_testing;

--- a/t/20-unit/Sub-Meta-Test/test_interface_error_message.t
+++ b/t/20-unit/Sub-Meta-Test/test_interface_error_message.t
@@ -1,15 +1,15 @@
 use Test2::V0;
 
 use Sub::Meta;
-use Sub::Meta::Test qw(test_interface_error_message);
+use Sub::Meta::Test qw(test_error_message);
 
-subtest 'Fail: test_interface_error_message' => sub {
+subtest 'Fail: test_error_message' => sub {
     my $events = intercept {
         my $meta = Sub::Meta->new();
         my @tests = (
             hoge => { }, qr//,
         );
-        test_interface_error_message($meta, @tests);
+        test_error_message($meta, @tests);
     };
 
     is $events, array {

--- a/t/20-unit/Sub-Meta/error_message.t
+++ b/t/20-unit/Sub-Meta/error_message.t
@@ -1,7 +1,7 @@
 use Test2::V0;
 
 use Sub::Meta;
-use Sub::Meta::Test qw(test_interface_error_message);
+use Sub::Meta::Test qw(test_error_message);
 
 my $p1 = Sub::Meta::Parameters->new(args => ['Str']);
 my $p2 = Sub::Meta::Parameters->new(args => ['Int']);
@@ -21,7 +21,7 @@ subtest "{ subname => 'foo' }" => sub {
         pass       => { subname => 'foo' },                    qr//, # valid
         pass       => { fullname => 'path::foo' },             qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "no args: {}" => sub {
@@ -30,7 +30,7 @@ subtest "no args: {}" => sub {
         pass_child => { subname => 'foo' }, qr/^should not have subname. got: foo/,
         pass       => { },                  qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "method: { is_method => 1 }" => sub {
@@ -39,7 +39,7 @@ subtest "method: { is_method => 1 }" => sub {
         fail => { is_method => 0 }, qr/^invalid method/,
         pass => { is_method => 1 }, qr//, # valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "p1: { parameters => \$p1 }" => sub {
@@ -49,7 +49,7 @@ subtest "p1: { parameters => \$p1 }" => sub {
         fail => {  },                  qr/^invalid parameters:/,
         pass => { parameters => $p1 }, qr//, #valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 subtest "{ returns => \$r1 }" => sub {
@@ -59,7 +59,7 @@ subtest "{ returns => \$r1 }" => sub {
         fail => {  },               qr/^invalid returns:/,
         pass => { returns => $r1 }, qr//, #valid
     );
-    test_interface_error_message($meta, @tests);
+    test_error_message($meta, @tests);
 };
 
 done_testing;

--- a/t/20-unit/Sub-Meta/is_same_interface.t
+++ b/t/20-unit/Sub-Meta/is_same_interface.t
@@ -14,8 +14,8 @@ my $obj = bless {} => 'Some';
 subtest "no args: {  }" => sub {
     my $meta = Sub::Meta->new({ });
     my @tests = (
-        fail => 'invalid subname'    => { subname => 'foo' },
-        pass => 'valid'              => {  },
+        pass_child => 'invalid subname'    => { subname => 'foo' },
+        pass       => 'valid'              => {  },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -23,14 +23,14 @@ subtest "no args: {  }" => sub {
 subtest "{ subname => 'foo' }" => sub {
     my $meta = Sub::Meta->new({ subname => 'foo' });
     my @tests = (
-        fail => 'other is undef'         => undef,
-        fail => 'other is not Sub::Meta' => $obj,
-        fail => 'invalid subname'        => { subname => 'bar' },
-        fail => 'undef subname'          => { subname => undef },
-        fail => 'invalid parameters'     => { subname => 'foo', parameters => $p1 },
-        fail => 'invalid returns'        => { subname => 'foo', returns => $r1 }, ,
-        pass => 'valid'                  => { subname => 'foo' },
-        pass => 'valid w/ stashname'     => { fullname => 'path::foo' },
+        fail       => 'other is undef'         => undef,
+        fail       => 'other is not Sub::Meta' => $obj,
+        fail       => 'invalid subname'        => { subname => 'bar' },
+        fail       => 'undef subname'          => { subname => undef },
+        pass_child => 'invalid parameters'     => { subname => 'foo', parameters => $p1 },
+        pass_child => 'invalid returns'        => { subname => 'foo', returns => $r1 }, ,
+        pass       => 'valid'                  => { subname => 'foo' },
+        pass       => 'valid w/ stashname'     => { fullname => 'path::foo' },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -38,12 +38,12 @@ subtest "{ subname => 'foo' }" => sub {
 subtest "one args: { parameters => \$p1 }" => sub {
     my $meta = Sub::Meta->new({ parameters => $p1 });
     my @tests = (
-        fail => 'invalid subname'    => { subname => 'foo' },
-        fail => 'invalid parameters' => { parameters => $p2 },
-        fail => 'no parameters'      => {  },
-        fail => 'invalid subname'    => { parameters => $p1, subname => 'foo' }, 
-        fail => 'invalid returns'    => { parameters => $p1, returns => $r1 }, 
-        pass => 'valid'              => { parameters => $p1 },
+        fail       => 'invalid subname'    => { subname => 'foo' },
+        fail       => 'invalid parameters' => { parameters => $p2 },
+        fail       => 'no parameters'      => {  },
+        pass_child => 'invalid subname'    => { parameters => $p1, subname => 'foo' }, 
+        pass_child => 'invalid returns'    => { parameters => $p1, returns => $r1 }, 
+        pass       => 'valid'              => { parameters => $p1 },
     );
     test_is_same_interface($meta, @tests);
 };
@@ -51,11 +51,11 @@ subtest "one args: { parameters => \$p1 }" => sub {
 subtest "returns: { returns => \$r1 }" => sub {
     my $meta = Sub::Meta->new({ returns => $r1 });
     my @tests = (
-        fail => 'invalid returns'    => { returns => $r2 },
-        fail => 'no returns'         => {  },
-        fail => 'invalid subname'    => { returns => $r1, subname => 'foo' }, 
-        fail => 'invalid parameters' => { returns => $r1, parameters => $p1 },
-        pass => 'valid'              => { returns => $r1 },
+        fail       => 'invalid returns'    => { returns => $r2 },
+        fail       => 'no returns'         => {  },
+        pass_child => 'invalid subname'    => { returns => $r1, subname => 'foo' }, 
+        pass_child => 'invalid parameters' => { returns => $r1, parameters => $p1 },
+        pass       => 'valid'              => { returns => $r1 },
     );
     test_is_same_interface($meta, @tests);
 };


### PR DESCRIPTION
This pull request has the following changes:

- [BREAKING CHANGE] rename interface_error_message to error_message
- add is_relaxed_same_interface
- add relaxed_error_message
- [fixed bug] self.is_method eq other.is_method
